### PR TITLE
Enforce TDD, 95% coverage floor, and strong Python typing

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -27,6 +27,15 @@ Reference and strictly follow these documents when making any changes:
    - `standards/process/13_git_version_control_standards.md` - Git workflow, commits, branching
    - `standards/process/14_code_review_expectations.md` - Code review process and expectations
 
+## Non-Negotiable Requirements
+
+These mandates apply to ALL code changes, regardless of scope or urgency:
+
+1. **Test-Driven Development (TDD) is mandatory.** Write failing tests before implementation code. Red → Green → Refactor. No exceptions except thin UI rendering layers, generated code, and one-off scripts.
+2. **95% test coverage is the absolute minimum** for any module, in any layer. Domain must reach 100%. Bug fixes must include regression tests.
+3. **Python code must be strongly typed throughout.** Every function, method, variable, and class attribute requires type annotations. `mypy --strict` must pass with zero errors. No `# type: ignore` without justification.
+4. **Build for automated regression and local full-stack testing.** Tests must run locally without external dependencies. Use test containers and in-memory substitutes. CI and local test suites must be identical.
+
 ## Behavior Rules
 
 1. **Always check relevant standards** before making changes:
@@ -81,10 +90,13 @@ When working with code, automatically detect the language and apply the correspo
 ## Violation Detection
 
 When reviewing code, automatically check for:
+- **TDD compliance** — tests committed before or alongside implementation
+- **Coverage below 95%** in any modified module
+- **Untyped Python code** — all functions, methods, and variables must have type annotations
+- **Missing regression tests** for bug fixes
 - Architecture violations (Domain importing Infrastructure)
 - Naming convention mismatches
 - Missing error handling
-- Insufficient test coverage
 - Documentation gaps
 - Git commit message format issues
 

--- a/standards/agents/claude-code/CLAUDE.md.template
+++ b/standards/agents/claude-code/CLAUDE.md.template
@@ -60,14 +60,19 @@ docs/                # Architecture docs, ADRs, development guides
 
 ## Testing
 
+- **Methodology:** **Test-Driven Development (TDD) is mandatory.** Write failing tests before writing implementation code. Red → Green → Refactor.
 - **Structure:** Inline test modules within source files. Integration tests in `tests/` directory.
-- **Coverage baselines:**
+- **Regression:** Every bug fix MUST include a regression test that reproduces the bug.
+- **Local full-stack:** `make dev` + `make test` must run the entire stack locally with no external dependencies.
+- **Coverage baselines (95% absolute minimum):**
 
 | Layer | Min Coverage |
 |-------|-------------|
-| Core / Domain | 95% |
-| Application / Shell | 90% |
-| Infrastructure | 80% |
+| Core / Domain | 100% |
+| Application / Shell | 95% |
+| Infrastructure | 95% |
+
+- **Python typing:** All Python code must be strongly typed. `mypy --strict` must pass with zero errors.
 
 ---
 
@@ -91,6 +96,10 @@ Follow Conventional Commits: `type(scope): subject`
 
 ## What NOT To Do
 
+- **Do not write implementation code before writing a failing test.** TDD is mandatory.
+- **Do not submit code below 95% test coverage** in any module.
+- **Do not write untyped Python code.** Every function, method, and variable must have type annotations. `mypy --strict` must pass.
+- **Do not skip regression tests** when fixing bugs — every fix needs a test proving the bug existed.
 - [Anti-pattern 1: describe what to avoid and why]
 - [Anti-pattern 2: describe what to avoid and why]
 - Do not modify the root checkout from an automated agent session — use a git worktree.

--- a/standards/agents/copilot/.github/copilot-instructions.md
+++ b/standards/agents/copilot/.github/copilot-instructions.md
@@ -27,6 +27,15 @@ This project follows comprehensive development standards. Reference these docume
 - `standards/process/13_git_version_control_standards.md` - Git workflow, commits, branching
 - `standards/process/14_code_review_expectations.md` - Code review process and expectations
 
+## Non-Negotiable Requirements
+
+These mandates apply to ALL code changes, regardless of scope or urgency:
+
+1. **Test-Driven Development (TDD) is mandatory.** Write failing tests before implementation code. Red → Green → Refactor. No exceptions except thin UI rendering layers, generated code, and one-off scripts.
+2. **95% test coverage is the absolute minimum** for any module, in any layer. Domain must reach 100%. Bug fixes must include regression tests.
+3. **Python code must be strongly typed throughout.** Every function, method, variable, and class attribute requires type annotations. `mypy --strict` must pass with zero errors.
+4. **Build for automated regression and local full-stack testing.** Tests must run locally without external dependencies. Use test containers and in-memory substitutes.
+
 ## Behavior Rules
 
 1. **Always check relevant standards** before making changes:
@@ -75,10 +84,13 @@ When working with code, automatically detect the language and apply the correspo
 ## Violation Detection
 
 When reviewing code, automatically check for:
+- **TDD compliance** — tests committed before or alongside implementation
+- **Coverage below 95%** in any modified module
+- **Untyped Python code** — all functions, methods, and variables must have type annotations
+- **Missing regression tests** for bug fixes
 - Architecture violations (Domain importing Infrastructure)
 - Naming convention mismatches
 - Missing error handling
-- Insufficient test coverage
 - Documentation gaps
 - Git commit message format issues
 

--- a/standards/architecture/00_project_standards_and_architecture.md
+++ b/standards/architecture/00_project_standards_and_architecture.md
@@ -85,22 +85,43 @@ Strict adherence required. Violations must be justified in code comments.
 ### Type Safety
 
 * **TypeScript:** Strict mode enabled. No `any` without explicit justification.
-* **Python:** Type hints required for all public APIs. Use `mypy` or `pyright`.
+* **Python:** **All code must be strongly typed.** Type hints required on every function, method, variable declaration, and class attribute — not just public APIs. Run `mypy` or `pyright` in **strict mode** with zero errors. No `# type: ignore` without an accompanying comment explaining why.
 * **Rust:** Leverage type system. Use `Result<T, E>` for fallible operations.
 
 ## 4. Testing Standards
+
+### Test-Driven Development (TDD) — Mandatory
+
+**All new code MUST be written using Test-Driven Development when possible.** TDD is the default methodology, not an optional practice.
+
+1. **Red:** Write a failing test that defines the expected behavior.
+2. **Green:** Write the minimum code to make the test pass.
+3. **Refactor:** Clean up the implementation while keeping tests green.
+
+When modifying existing untested code, write characterization tests first before making changes.
+
+### Automated Regression & Local Full-Stack Testing
+
+* **Regression tests:** Every bug fix MUST include a test that reproduces the bug and prevents recurrence.
+* **Local full-stack testing:** The complete application stack must be runnable locally via `make dev` + `make test`. Use Docker Compose, test containers, or in-memory substitutes for all external dependencies.
+* **CI parity:** Local `make test` must run the same suite as CI. No environment-specific test gaps.
 
 ### Test Structure
 
 * **Unit Tests:** Test domain logic in isolation. Mock external dependencies.
 * **Integration Tests:** Test layer interactions. Use test databases/containers.
 * **E2E Tests:** Test complete user workflows. Minimal set, high-value scenarios.
+* **Regression Tests:** Every bug fix includes a test that prevents recurrence.
 
-### Coverage Requirements
+### Coverage Requirements — 95% Absolute Minimum
+
+**95% test coverage is the absolute minimum for any module, in any layer.**
 
 * **Domain:** 100% coverage. Business logic must be fully tested.
-* **Application:** 90%+ coverage. All use cases tested.
-* **Infrastructure:** 80%+ coverage. Critical paths tested.
+* **Application:** 95%+ coverage. All use cases and orchestration paths tested.
+* **Infrastructure:** 95%+ coverage. Adapters and integrations tested.
+
+Coverage gates MUST be enforced in CI. A PR that drops any module below 95% MUST NOT be merged.
 
 ### Test Organization
 

--- a/standards/architecture/01_automation_standards.md
+++ b/standards/architecture/01_automation_standards.md
@@ -206,16 +206,16 @@ Targets without `## description` will not appear in `make ls`. This is intention
 Coverage baselines should be configurable per-module via Make variables, not a single global threshold:
 
 ```makefile
-CORE_COV_MIN  ?= 95
-APP_COV_MIN   ?= 90
-INFRA_COV_MIN ?= 80
+CORE_COV_MIN  ?= 100
+APP_COV_MIN   ?= 95
+INFRA_COV_MIN ?= 95
 
 coverage-check: ## Enforce per-module coverage baselines
 	@echo "Checking coverage baselines..."
 	# Run coverage tool per module and compare against threshold
 ```
 
-This allows projects to set tighter constraints on core/domain code (where bugs are most expensive) and lower thresholds on infrastructure (where testing is harder and less valuable).
+**95% coverage is the absolute minimum for any module.** Projects may raise these values but never lower them below 95%. Use test containers, mocks, and in-memory substitutes to achieve infrastructure coverage.
 
 ## 6. Seed Data Targets
 

--- a/standards/architecture/17_resilient_architecture_patterns.md
+++ b/standards/architecture/17_resilient_architecture_patterns.md
@@ -6,24 +6,28 @@ Instead of a single global coverage threshold, enforce coverage baselines per ar
 
 ### Recommended Baselines
 
+**95% is the absolute minimum for any module.** No layer is exempt.
+
 | Layer | Min Coverage | Rationale |
 |-------|-------------|-----------|
-| Domain / Core | 95-100% | Pure business logic, no external dependencies, highest risk |
-| Application / Shell | 90%+ | Orchestration logic, moderate complexity |
-| Infrastructure / Integration | 80%+ | External adapters, harder to test exhaustively |
+| Domain / Core | 100% | Pure business logic, no external dependencies, highest risk |
+| Application / Shell | 95%+ | Orchestration logic, all use cases tested |
+| Infrastructure / Integration | 95%+ | External adapters — use test containers and mocks to reach threshold |
 
 ### Enforcement
 
-Define per-module thresholds as Make variables so they can be overridden per-project:
+Define per-module thresholds as Make variables. **The floor is 95% — projects may raise but never lower these values:**
 
 ```makefile
-CORE_COV_MIN  ?= 95
-APP_COV_MIN   ?= 90
-INFRA_COV_MIN ?= 80
+CORE_COV_MIN  ?= 100
+APP_COV_MIN   ?= 95
+INFRA_COV_MIN ?= 95
 
 coverage-check: ## Enforce per-module coverage baselines
 	# Run coverage tool per module, compare against threshold
 ```
+
+A PR that drops any module below its coverage gate MUST NOT be merged.
 
 ## 2. Pure Render Logic
 

--- a/standards/languages/03_python_standards.md
+++ b/standards/languages/03_python_standards.md
@@ -10,7 +10,7 @@
 
 * **Formatter:** `black` with line length 100. Run via `make fmt`.
 * **Linter:** `ruff` for fast linting. `pylint` for comprehensive analysis.
-* **Type Checker:** `mypy` or `pyright` in strict mode. Type hints required for all public APIs.
+* **Type Checker:** `mypy` or `pyright` in **strict mode** with zero errors. See Section 4 for full typing requirements.
 
 ### Configuration
 
@@ -38,10 +38,31 @@ warn_unused_configs = true
 * **Private:** `_single_leading_underscore` (module-level)
 * **Name Mangling:** `__double_leading_underscore` (class-level, avoid unless necessary)
 
-## 4. Type Hints
+## 4. Type Hints — All Code Must Be Strongly Typed
 
-* **Required:** All public functions, methods, class attributes.
-* **Style:** Use `typing` module. Prefer `list[str]` over `List[str]` (Python 3.9+).
+**Python code MUST be strongly typed throughout. This is not limited to public APIs — every function, method, variable declaration, class attribute, and return type requires explicit type annotations.**
+
+### Requirements
+
+* **All functions and methods:** Parameter types and return types are mandatory — no exceptions. This includes private/internal functions.
+* **Variables:** Annotate variables when the type is not obvious from assignment. Always annotate empty collections, `None`-initialized variables, and class attributes.
+* **mypy strict mode:** Must pass with zero errors. The following `pyproject.toml` configuration is mandatory:
+  ```toml
+  [tool.mypy]
+  strict = true
+  warn_return_any = true
+  warn_unused_configs = true
+  disallow_untyped_defs = true
+  disallow_incomplete_defs = true
+  check_untyped_defs = true
+  disallow_any_generics = true
+  no_implicit_optional = true
+  warn_redundant_casts = true
+  warn_unused_ignores = true
+  ```
+* **No `# type: ignore`** without an accompanying comment explaining why and a linked issue for resolution.
+* **No `Any`** without explicit justification in a comment. Prefer `object` or `Unknown` patterns.
+* **Style:** Prefer `list[str]` over `List[str]` (Python 3.9+). Use `|` union syntax over `Union` (Python 3.10+).
 * **Protocols:** Use `Protocol` for structural subtyping instead of ABCs when appropriate.
 * **Generics:** Use `TypeVar` and `Generic` for reusable type parameters.
 
@@ -55,6 +76,16 @@ T = TypeVar("T")
 class Repository(Protocol[T]):
     def find_by_id(self, id: str) -> T | None: ...
     def save(self, entity: T) -> None: ...
+
+# All functions — including private ones — must be fully typed
+def _validate_email(email: str) -> bool:
+    return "@" in email
+
+class UserService:
+    _cache: dict[str, User]  # Class attributes must be typed
+
+    def __init__(self, repo: Repository[User]) -> None:
+        self._cache = {}
 ```
 
 ## 5. Project Structure
@@ -77,9 +108,12 @@ package_name/
 
 ## 6. Testing
 
+* **Methodology:** **Test-Driven Development (TDD) is mandatory.** Write failing tests before implementation code.
 * **Framework:** `pytest`. Use fixtures for test dependencies.
-* **Coverage:** `pytest-cov`. Target 90%+ for application layer, 100% for domain.
+* **Coverage:** `pytest-cov`. **95% is the absolute minimum for any module.** Target 100% for domain, 95%+ for application and infrastructure.
+* **Regression:** Every bug fix must include a regression test.
 * **Mocking:** `unittest.mock` or `pytest-mock`. Mock external dependencies only.
+* **Local full-stack:** Tests must be runnable locally without external dependencies. Use `testcontainers` or in-memory substitutes.
 
 ### Test Structure
 

--- a/standards/process/14_code_review_expectations.md
+++ b/standards/process/14_code_review_expectations.md
@@ -47,8 +47,11 @@
 - [ ] Code works as described in PR description
 - [ ] Follows project architecture and patterns
 - [ ] Meets coding standards (formatting, naming, structure)
-- [ ] Includes appropriate tests (unit, integration, E2E)
-- [ ] Tests pass and coverage is adequate
+- [ ] **TDD was followed** — tests were written before implementation (check commit order)
+- [ ] Includes appropriate tests (unit, integration, E2E, regression)
+- [ ] **Test coverage is ≥ 95%** in every modified module (100% for domain)
+- [ ] Bug fixes include a regression test that reproduces the original bug
+- [ ] **Python code is fully typed** — `mypy --strict` passes with zero errors
 - [ ] Documentation is updated (code comments, README, user docs)
 - [ ] No security vulnerabilities introduced
 - [ ] No obvious performance regressions
@@ -145,7 +148,9 @@ How was this tested?
 
 * **Functionality:** Code works as intended
 * **Standards:** Meets project coding standards
-* **Tests:** Adequate test coverage, all tests pass
+* **TDD:** Evidence that tests were written before implementation (test commits precede implementation commits)
+* **Tests:** ≥ 95% coverage in all modified modules, all tests pass, regression tests for bug fixes
+* **Type Safety:** Python code passes `mypy --strict` with zero errors; TypeScript uses strict mode
 * **Documentation:** Documentation is updated
 * **Security:** No security concerns
 * **Architecture:** Follows project architecture

--- a/standards/process/15_agent_workflow_standards.md
+++ b/standards/process/15_agent_workflow_standards.md
@@ -17,6 +17,9 @@ cd .claude/worktrees/<branch-name>
 
 * Never modify files in the root checkout from an automated agent session.
 * Create a new worktree at the start of each feature/fix branch.
+* **Follow TDD:** Write failing tests before implementation code. This applies to agents as well as humans.
+* **Maintain ≥ 95% test coverage** in all modified modules. Run coverage checks before considering work complete.
+* **Python code must be strongly typed:** All functions, methods, and variables must have type annotations. `mypy --strict` must pass with zero errors.
 * Run `make ci` within the worktree before considering work complete.
 * **Clean up immediately after merge.** Remove worktree, delete local branch, delete remote branch:
   ```bash

--- a/standards/shared/core-standards.md
+++ b/standards/shared/core-standards.md
@@ -69,22 +69,53 @@ Strict adherence required. Violations must be justified in code comments.
 ### Type Safety
 
 - **TypeScript:** Strict mode enabled. No `any` without explicit justification.
-- **Python:** Type hints required for all public APIs. Use `mypy` or `pyright`.
+- **Python:** **All code must be strongly typed.** Type hints required on every function, method, variable declaration, and class attribute — not just public APIs. Run `mypy` or `pyright` in **strict mode** with zero errors. No `# type: ignore` without an accompanying comment explaining why.
 - **Rust:** Leverage type system. Use `Result<T, E>` for fallible operations.
 
 ## Testing Standards
+
+### Test-Driven Development (TDD) — Mandatory
+
+**All new code MUST be written using Test-Driven Development when possible.** TDD is not optional — it is the default methodology.
+
+1. **Red:** Write a failing test that defines the expected behavior.
+2. **Green:** Write the minimum code to make the test pass.
+3. **Refactor:** Clean up the implementation while keeping tests green.
+
+TDD applies to all layers — domain logic, application services, infrastructure adapters, and API endpoints. The only acceptable exceptions are:
+- Thin UI rendering layers that consume view models (the view model logic itself must be TDD).
+- Generated code (e.g., ORM migrations, protobuf stubs).
+- One-off scripts that will not be maintained.
+
+When modifying existing code that lacks tests, **write characterization tests first** before making changes.
+
+### Automated Regression & Local Full-Stack Testing
+
+Projects MUST build testing infrastructure that supports:
+
+- **Automated regression testing:** Every bug fix must include a regression test that reproduces the bug before the fix and passes after. CI must run the full regression suite on every PR.
+- **Local full-stack testing:** Developers and agents must be able to run the complete application stack locally (via `make dev` + `make test`) without relying on shared environments. Use Docker Compose, test containers, or in-memory substitutes to provide all external dependencies (databases, message queues, third-party APIs) locally.
+- **Test fixtures and factories:** Maintain reusable test data builders and fixtures. Never rely on production data for testing. Use deterministic seed data (see `make seed` in automation standards).
+- **CI parity:** Local test execution (`make test`) must run the same test suite as CI. No "works on CI but not locally" or vice versa.
 
 ### Test Structure
 
 - **Unit Tests:** Test domain logic in isolation. Mock external dependencies.
 - **Integration Tests:** Test layer interactions. Use test databases/containers.
 - **E2E Tests:** Test complete user workflows. Minimal set, high-value scenarios.
+- **Regression Tests:** Every bug fix includes a test that prevents recurrence.
 
-### Coverage Requirements
+### Coverage Requirements — 95% Absolute Minimum
 
-- **Domain:** 100% coverage. Business logic must be fully tested.
-- **Application:** 90%+ coverage. All use cases tested.
-- **Infrastructure:** 80%+ coverage. Critical paths tested.
+**95% test coverage is the absolute minimum for any module, in any layer.** There are no exceptions to this floor.
+
+| Layer | Min Coverage | Notes |
+|-------|-------------|-------|
+| Domain / Core | 100% | Pure business logic — no excuses |
+| Application / Shell | 95%+ | All use cases and orchestration paths tested |
+| Infrastructure / Integration | 95%+ | Adapters, repositories, and external integrations tested |
+
+Coverage gates MUST be enforced in CI. A PR that drops coverage below 95% in any module MUST NOT be merged.
 
 ### Test Organization
 


### PR DESCRIPTION
## Summary
- Mandate Test-Driven Development (TDD) as the default methodology across all standards documents and agent configurations
- Raise minimum test coverage from 80-90% to **95% absolute floor** for every module in every layer (100% for domain)
- Require **full strong typing** in all Python code (not just public APIs) with strict mypy configuration
- Add explicit requirements for automated regression testing and local full-stack testing infrastructure

## Files Changed (10)
- `standards/shared/core-standards.md` — Added TDD mandate, regression/full-stack testing section, raised coverage floor, strengthened Python typing
- `standards/architecture/00_project_standards_and_architecture.md` — Mirrored core standards updates
- `standards/architecture/01_automation_standards.md` — Updated Make coverage gate variables to 95/95/100
- `standards/architecture/17_resilient_architecture_patterns.md` — Updated coverage baselines table and enforcement language
- `standards/languages/03_python_standards.md` — Expanded typing section to require all code (not just public APIs), added full mypy strict config, added TDD to testing section
- `standards/process/14_code_review_expectations.md` — Added TDD, coverage, typing, and regression test checks to review checklist and approval criteria
- `standards/process/15_agent_workflow_standards.md` — Added TDD, coverage, and typing rules for agent workflows
- `standards/agents/claude-code/CLAUDE.md.template` — Updated testing section and "What NOT To Do" anti-patterns
- `.cursorrules` — Added "Non-Negotiable Requirements" section with all four mandates
- `standards/agents/copilot/.github/copilot-instructions.md` — Same non-negotiable requirements section

## Test plan
- [ ] Review that all 10 files consistently express the same standards
- [ ] Verify no contradictions between core-standards.md and language/architecture docs
- [ ] Confirm coverage gate Make variables match across automation and architecture docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)