### PR TITLE
Align language-specific coverage targets with 95% minimum

### DIFF
--- a/standards/languages/04_java_standards.md
+++ b/standards/languages/04_java_standards.md
@@ -87,7 +87,7 @@ public sealed interface Result<T> permits Success, Failure {
 
 * **Framework:** `JUnit 5` with `AssertJ` for assertions.
 * **Mocking:** `Mockito` for mocks. Use `@Mock` and `@InjectMocks`.
-* **Coverage:** `JaCoCo`. Target 90%+ for application, 100% for domain.
+* **Coverage:** `JaCoCo`. **95% is the absolute minimum for any module.** Target 100% for domain, 95%+ for application and infrastructure.
 
 ### Test Structure
 

--- a/standards/languages/06_swift_standards.md
+++ b/standards/languages/06_swift_standards.md
@@ -104,7 +104,7 @@ enum DomainError: Error {
 
 * **Framework:** `XCTest`. Use `XCTAssert*` functions.
 * **Mocking:** Use protocols for testability. Create test doubles manually or use `Mockingbird`.
-* **Coverage:** Enable code coverage in Xcode. Target 90%+ for application, 100% for domain.
+* **Coverage:** Enable code coverage in Xcode. **95% is the absolute minimum for any module.** Target 100% for domain, 95%+ for application and infrastructure.
 
 ### Test Structure
 

--- a/standards/languages/07_dart_standards.md
+++ b/standards/languages/07_dart_standards.md
@@ -100,7 +100,7 @@ class Failure<T> extends Result<T> {
 
 * **Framework:** `test` package. Use `expect()` for assertions.
 * **Mocking:** `mockito` with code generation. Use `@GenerateMocks` annotation.
-* **Coverage:** `test_coverage`. Target 90%+ for application, 100% for domain.
+* **Coverage:** `test_coverage`. **95% is the absolute minimum for any module.** Target 100% for domain, 95%+ for application and infrastructure.
 
 ### Test Structure
 

--- a/standards/languages/08_typescript_standards.md
+++ b/standards/languages/08_typescript_standards.md
@@ -115,7 +115,7 @@ class InvalidEmailError extends DomainError {
 
 * **Framework:** `vitest` or `jest`. Use `@testing-library` for component tests.
 * **Mocking:** `vitest` built-in mocking or `jest.mock()`. Mock external dependencies.
-* **Coverage:** Target 90%+ for application, 100% for domain.
+* **Coverage:** **95% is the absolute minimum for any module.** Target 100% for domain, 95%+ for application and infrastructure.
 
 ### Test Structure
 

--- a/standards/languages/09_javascript_standards.md
+++ b/standards/languages/09_javascript_standards.md
@@ -119,7 +119,7 @@ class InvalidEmailError extends DomainError {
 
 * **Framework:** `vitest` or `jest`. Use `@testing-library` for DOM testing.
 * **Mocking:** Use framework's built-in mocking. Mock external dependencies.
-* **Coverage:** Target 90%+ for application, 100% for domain.
+* **Coverage:** **95% is the absolute minimum for any module.** Target 100% for domain, 95%+ for application and infrastructure.
 
 ### Test Structure
 

--- a/standards/languages/10_rust_standards.md
+++ b/standards/languages/10_rust_standards.md
@@ -102,7 +102,7 @@ pub enum DomainError {
 
 * **Framework:** Built-in `#[test]` and `#[cfg(test)]`. Use `cargo test`.
 * **Mocking:** Use `mockall` for trait mocking. Use test doubles for integration tests.
-* **Coverage:** Use `cargo-tarpaulin` or `grcov`. Target 90%+ for application, 100% for domain.
+* **Coverage:** Use `cargo-tarpaulin` or `grcov`. **95% is the absolute minimum for any module.** Target 100% for domain, 95%+ for application and infrastructure.
 
 ### Test Structure
 


### PR DESCRIPTION
## Summary
- Updates 6 language standards files (Java, Swift, Dart, TypeScript, JavaScript, Rust) to match the 95% coverage floor established in PR #15
- Python was already updated in the prior PR; Kotlin and Zig don't have explicit coverage lines

## Test plan
- [ ] Verify all language files now state 95% minimum: `grep -r "coverage" standards/languages/`
- [ ] Confirm consistency with `core-standards.md` and `17_resilient_architecture_patterns.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)