### PR TITLE
fix: correct invalid Claude Code settings.json template

### DIFF
--- a/standards/agents/claude-code/settings.json.example
+++ b/standards/agents/claude-code/settings.json.example
@@ -1,12 +1,7 @@
 {
-  "$schema": "https://claude.ai/claude-code-settings-schema.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
-      "Read",
-      "Edit",
-      "Write",
-      "Glob",
-      "Grep",
       "Bash(make ci)",
       "Bash(make check)",
       "Bash(make lint)",
@@ -14,10 +9,6 @@
       "Bash(make fmt)",
       "Bash(make ls)",
       "Bash(make seed)",
-      "Bash(cargo test*)",
-      "Bash(cargo check*)",
-      "Bash(cargo clippy*)",
-      "Bash(cargo fmt*)",
       "Bash(git status*)",
       "Bash(git diff*)",
       "Bash(git log*)",
@@ -29,7 +20,9 @@
     "deny": [
       "Bash(git push --force*)",
       "Bash(git reset --hard*)",
-      "Bash(rm -rf*)"
+      "Bash(rm -rf*)",
+      "Read(./.env)",
+      "Read(./.env.*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Fix `$schema` URL from non-existent `https://claude.ai/claude-code-settings-schema.json` to valid `https://json.schemastore.org/claude-code-settings.json`
- Remove read-only tools (`Read`, `Edit`, `Write`, `Glob`, `Grep`) from allow list — these don't need explicit permission in Claude Code
- Remove Rust-specific Cargo commands (`cargo test/check/clippy/fmt`) — template should be language-agnostic since it's deployed to all new projects
- Add `.env` file deny rules to prevent reading secrets

## Test plan
- [ ] Run `scripts/setup.sh` against a fresh project and verify `.claude/settings.json` is valid
- [ ] Confirm Claude Code accepts the settings file without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)