### PR TITLE
fix(action): extract Python heredoc from standards-review action.yml

### DIFF
--- a/.github/actions/standards-review/action.yml
+++ b/.github/actions/standards-review/action.yml
@@ -85,24 +85,7 @@ runs:
 
           # Parse JSON results array using python3 (available on all GitHub-hosted runners)
           if command -v python3 >/dev/null 2>&1; then
-            python3 - "$LINT_RESULTS" <<'PYEOF'
-import sys, json
-
-raw = sys.argv[1] if len(sys.argv) > 1 else "{}"
-try:
-    data = json.loads(raw)
-    results = data.get("results", [])
-except (json.JSONDecodeError, ValueError):
-    results = []
-
-icons = {"PASS": ":white_check_mark:", "WARN": ":warning:", "FAIL": ":x:"}
-for r in results:
-    status = r.get("status", "")
-    check = r.get("check", "")
-    message = r.get("message", "").replace("|", "\\|").replace("\n", " ")
-    icon = icons.get(status, ":grey_question:")
-    print(f"| {icon} {status} | {check} | {message} |")
-PYEOF
+            python3 "${{ github.action_path }}/format-results.py" "$LINT_RESULTS"
           fi
 
           printf "\n---\n"

--- a/.github/actions/standards-review/format-results.py
+++ b/.github/actions/standards-review/format-results.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Format lint-standards.sh JSON output as a Markdown table row per result."""
+import json
+import sys
+
+raw = sys.argv[1] if len(sys.argv) > 1 else "{}"
+try:
+    results = json.loads(raw).get("results", [])
+except (json.JSONDecodeError, ValueError):
+    results = []
+
+icons = {"PASS": ":white_check_mark:", "WARN": ":warning:", "FAIL": ":x:"}
+for r in results:
+    status = r.get("status", "")
+    check = r.get("check", "")
+    message = r.get("message", "").replace("|", "\\|").replace("\n", " ")
+    icon = icons.get(status, ":grey_question:")
+    print(f"| {icon} {status} | {check} | {message} |")

--- a/.github/actions/standards-review/format-results.py
+++ b/.github/actions/standards-review/format-results.py
@@ -4,10 +4,15 @@ import json
 import sys
 
 raw = sys.argv[1] if len(sys.argv) > 1 else "{}"
+results = []
 try:
-    results = json.loads(raw).get("results", [])
+    data = json.loads(raw)
+    if isinstance(data, dict):
+        raw_results = data.get("results", [])
+        if isinstance(raw_results, list):
+            results = raw_results
 except (json.JSONDecodeError, ValueError):
-    results = []
+    pass
 
 icons = {"PASS": ":white_check_mark:", "WARN": ":warning:", "FAIL": ":x:"}
 for r in results:

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ test-scripts: ## Test setup and sync scripts
 	@bash -n bin/gh-task && echo "✅ gh-task syntax valid"
 	@echo "Testing lint check scripts..."
 	@find scripts/lint-checks -name "*.sh" -exec bash -n {} \; && echo "✅ All lint check scripts syntax valid"
+	@echo "Testing format-results.py..."
+	@./scripts/test-format-results.sh
 
 test-bootstrap: ## Run functional tests on bootstrap scripts
 	@./scripts/test-bootstrap.sh

--- a/scripts/test-format-results.sh
+++ b/scripts/test-format-results.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Test scripts/format-results.py against representative inputs.
+#
+# Usage:
+#   ./scripts/test-format-results.sh
+#
+# Run from the standards repo root (or any directory; uses absolute path
+# discovery via $0).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FORMATTER="$REPO_ROOT/.github/actions/standards-review/format-results.py"
+
+if [ ! -f "$FORMATTER" ]; then
+    echo "FAIL: formatter not found at $FORMATTER" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        printf "  ✅ %s\n" "$label"
+    else
+        FAIL=$((FAIL + 1))
+        printf "  ❌ %s\n" "$label"
+        printf "     expected: %q\n" "$expected"
+        printf "     actual:   %q\n" "$actual"
+    fi
+}
+
+# Test 1: valid JSON with multiple results — emits one row per result
+out=$(python3 "$FORMATTER" '{"results":[{"status":"PASS","check":"naming","message":"ok"},{"status":"FAIL","check":"secrets","message":"hardcoded key | found"}]}')
+expected=$(printf '| :white_check_mark: PASS | naming | ok |\n| :x: FAIL | secrets | hardcoded key \\| found |')
+assert_eq "valid JSON renders rows with pipe-escaping" "$expected" "$out"
+
+# Test 2: empty results array — emits nothing
+out=$(python3 "$FORMATTER" '{"results":[]}')
+assert_eq "empty results array → no output" "" "$out"
+
+# Test 3: malformed JSON — degrades to no output (does not crash)
+out=$(python3 "$FORMATTER" 'not-json')
+assert_eq "malformed JSON → no output" "" "$out"
+
+# Test 4: no args — uses default empty object → no output
+out=$(python3 "$FORMATTER")
+assert_eq "no args → no output" "" "$out"
+
+# Test 5: JSON root is an array (not object) — does not crash, no output
+out=$(python3 "$FORMATTER" '[]')
+assert_eq "JSON array root → no output (no AttributeError)" "" "$out"
+
+# Test 6: JSON root is null — does not crash, no output
+out=$(python3 "$FORMATTER" 'null')
+assert_eq "JSON null root → no output" "" "$out"
+
+# Test 7: JSON root is a string — does not crash, no output
+out=$(python3 "$FORMATTER" '"some string"')
+assert_eq "JSON string root → no output" "" "$out"
+
+# Test 8: results field is not a list — does not crash, no output
+out=$(python3 "$FORMATTER" '{"results":"not-a-list"}')
+assert_eq "results field non-list → no output" "" "$out"
+
+# Test 9: result missing fields — uses empty defaults, still emits row with grey_question icon
+out=$(python3 "$FORMATTER" '{"results":[{}]}')
+expected="| :grey_question:  |  |  |"
+assert_eq "result with missing fields → row with grey_question icon" "$expected" "$out"
+
+# Test 10: newlines in message are flattened to spaces (so table renders correctly)
+out=$(python3 "$FORMATTER" '{"results":[{"status":"WARN","check":"naming","message":"line1\nline2"}]}')
+expected="| :warning: WARN | naming | line1 line2 |"
+assert_eq "newlines in message flatten to spaces" "$expected" "$out"
+
+echo ""
+echo "format-results.py tests: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #64 — the `standards-review` composite action fails to load in any consumer repo with `could not find expected ':'` at line 91.

## Root cause

The `Post PR comment` step embeds a Python heredoc inside a `run: |` block. The block scalar's indent is 8 spaces, but the heredoc body sits at column 0. YAML terminates the literal block scalar at the first under-indented line, so by the time the parser reaches `raw = sys.argv[1] if len(sys.argv) > 1 else "{}"`, it's parsing Python as YAML and chokes on the colon.

## Change

- Move the formatter to `.github/actions/standards-review/format-results.py`.
- Replace the heredoc with `python3 "${{ github.action_path }}/format-results.py" "$LINT_RESULTS"`.
- YAML stays trivial; Python is independently testable.

## Verification

- ✅ `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly (3 steps).
- ✅ Confirmed the broken state on `main` reproduces the exact reported error (`line 89/91`).
- ✅ Smoke-tested `format-results.py` with valid JSON (pipe escaping intact), malformed JSON, and zero args — all produce expected output (rows, or empty).
- ✅ `make test-scripts` baseline still green.

## Test plan

- [ ] CI on this PR loads the action without error
- [ ] Re-run the failing workflow on `dalbrecht/sagegrouse#37` against this branch's submodule SHA to confirm the consumer-side fix