### PR TITLE
docs(release): Standards 1.1 release notes + blog post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-15
+
 ### Added
-- `.github/CODEOWNERS` — default code ownership (proc-03 compliance)
-- `.github/dependabot.yml` — automated dependency updates for npm and GitHub Actions (sec-01 compliance)
-- `docs/adr/0001-unified-standards-repository.md` — foundational architecture decision record (proc-01 compliance)
-- `standards/README.md` — directory structure and naming convention overview (proc-01 compliance)
-- `bin/README.md` — gh-task CLI overview with documentation links (proc-01 compliance)
-- Security checklist (P0/P1/P2) in PR template (sec-01 compliance)
-- Security standards sync in website build pipeline
-- Security section in website sidebar
-- "How It Works" page on website with architecture and sync pipeline details
-- Blog posts covering project release history
+- **Project governance & infrastructure**
+  - `.github/CODEOWNERS` — default code ownership (proc-03 compliance)
+  - `.github/dependabot.yml` — automated dependency updates for npm and GitHub Actions (sec-01 compliance)
+  - Security checklist (P0/P1/P2) in PR template (sec-01 compliance)
+- **Architecture & navigability docs**
+  - `docs/adr/0001-unified-standards-repository.md` — foundational architecture decision record (proc-01 compliance)
+  - `standards/README.md` — directory structure and naming convention overview (proc-01 compliance)
+  - `bin/README.md` — gh-task CLI overview with documentation links (proc-01 compliance)
+- **Website**
+  - "How It Works" page with architecture and sync pipeline details
+  - Security section in website sidebar
+  - Security standards sync in website build pipeline
+  - Blog posts covering project release history
+- **Drift detection**: `make doctor` gains `check_aiderrc_template_sync` — surfaces drift between root `.aiderrc` and the canonical `standards/agents/aider/aiderrc.template` (#34, #69)
 
 ### Changed
+- `.aiderrc` re-synced with canonical `aiderrc.template`; drops 97 lines of stale inline P0/P1 security list now sourced via the block assembly system (#34, #69)
+- Default Aider model bumped to `claude-sonnet-4-6` (current Sonnet 4.6 family alias) (#70)
 - Restructured `CHANGELOG.md` with versioned release sections
+
+### Fixed
+- `standards-review` composite GitHub Action failed to load in consumer repos with `could not find expected ':'` YAML parse error. A Python heredoc inside a `run: |` block was indented at column 0, terminating the YAML literal block scalar so the parser interpreted Python as YAML. The formatter is now a sibling `format-results.py` invoked via `${{ github.action_path }}` (#64, #66)
 
 ## [0.5.0] - 2026-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Security standards sync in website build pipeline
   - Blog posts covering project release history
 - **Drift detection**: `make doctor` gains `check_aiderrc_template_sync` — surfaces drift between root `.aiderrc` and the canonical `standards/agents/aider/aiderrc.template` (#34, #69)
+- **Antigravity Mission isolation** (#67, #72)
+  - `scripts/mission-set.sh <url>` / `scripts/mission-clear.sh` — atomic write/truncate of `.gemini/active_mission.log` with HTTPS-only validation
+  - `proc-04 § 5: Mission Isolation` — feature bracketing rules, lifecycle table (set/active/clear/stale), read protocol; renumbers prior § 5 to § 6
+  - `GEMINI.md > Active Mission Tracking` — read protocol all agents (Claude Code, Cursor, Aider, Codex, Gemini) follow before starting work
+- **Postgres MCP integration** (#67, #72)
+  - `.gemini/settings.json` ships a `postgres` MCP entry, opt-in via `POSTGRES_MCP_DATABASE_URL` env var; gracefully fails to start when env var unset
+  - `make doctor` gains `check_postgres_mcp` — warns when entry is present but env var is missing
+- **UI Change Validation protocol** (#68, #73)
+  - `proc-04 § 7: UI Change Validation` — file-extension trigger heuristic; render → screenshot → diff three-step workflow; human-gated comparison criteria (pixel-diff is too noisy to gate on); cross-agent invocation table
+  - `templates/assets-designs-README.md.example` — reference template projects copy when opting into the `assets/designs/` convention
+  - `standards/shared/blocks/role-app.md` — UI-validation requirement injected into every assembled `role: app` agent config via the existing block-assembly system
 
 ### Changed
 - `.aiderrc` re-synced with canonical `aiderrc.template`; drops 97 lines of stale inline P0/P1 security list now sourced via the block assembly system (#34, #69)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Security standards sync in website build pipeline
   - Blog posts covering project release history
 - **Drift detection**: `make doctor` gains `check_aiderrc_template_sync` — surfaces drift between root `.aiderrc` and the canonical `standards/agents/aider/aiderrc.template` (#34, #69)
+- **Antigravity Mission isolation** (#67, #72)
+  - `scripts/mission-set.sh <url>` / `scripts/mission-clear.sh` — atomic write/truncate of `.gemini/active_mission.log` with HTTPS-only validation
+  - `proc-04 § 5: Mission Isolation` — feature bracketing rules, lifecycle table (set/active/clear/stale), read protocol; renumbers prior § 5 to § 6
+  - `GEMINI.md > Active Mission Tracking` — read protocol all agents (Claude Code, Cursor, Aider, Codex, Gemini) follow before starting work
+- **Postgres MCP integration** (#67, #72)
+  - `.gemini/settings.json` ships a `postgres` MCP entry, opt-in via `POSTGRES_MCP_DATABASE_URL` env var; gracefully fails to start when env var unset
+  - `make doctor` gains `check_postgres_mcp` — warns when entry is present but env var is missing
+- **UI Change Validation protocol** (#68, #73)
+  - `proc-04 § 7: UI Change Validation` — file-extension trigger heuristic; render → screenshot → diff three-step workflow; human-gated comparison criteria (pixel-diff is too noisy to gate on); cross-agent invocation table
+  - `templates/assets-designs-README.md.example` — reference template projects copy when opting into the `assets/designs/` convention
+  - `standards/shared/blocks/role-app.md` — UI-validation requirement injected into every assembled `role: app` agent config via the existing block-assembly system
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,22 +12,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-15
+
 ### Added
 
-- `.github/CODEOWNERS` — default code ownership (proc-03 compliance)
-- `.github/dependabot.yml` — automated dependency updates for npm and GitHub Actions (sec-01 compliance)
-- `docs/adr/0001-unified-standards-repository.md` — foundational architecture decision record (proc-01 compliance)
-- `standards/README.md` — directory structure and naming convention overview (proc-01 compliance)
-- `bin/README.md` — gh-task CLI overview with documentation links (proc-01 compliance)
-- Security checklist (P0/P1/P2) in PR template (sec-01 compliance)
-- Security standards sync in website build pipeline
-- Security section in website sidebar
-- "How It Works" page on website with architecture and sync pipeline details
-- Blog posts covering project release history
+- **Project governance & infrastructure**
+  - `.github/CODEOWNERS` — default code ownership (proc-03 compliance)
+  - `.github/dependabot.yml` — automated dependency updates for npm and GitHub Actions (sec-01 compliance)
+  - Security checklist (P0/P1/P2) in PR template (sec-01 compliance)
+- **Architecture & navigability docs**
+  - `docs/adr/0001-unified-standards-repository.md` — foundational architecture decision record (proc-01 compliance)
+  - `standards/README.md` — directory structure and naming convention overview (proc-01 compliance)
+  - `bin/README.md` — gh-task CLI overview with documentation links (proc-01 compliance)
+- **Website**
+  - "How It Works" page with architecture and sync pipeline details
+  - Security section in website sidebar
+  - Security standards sync in website build pipeline
+  - Blog posts covering project release history
+- **Drift detection**: `make doctor` gains `check_aiderrc_template_sync` — surfaces drift between root `.aiderrc` and the canonical `standards/agents/aider/aiderrc.template` (#34, #69)
 
 ### Changed
 
+- `.aiderrc` re-synced with canonical `aiderrc.template`; drops 97 lines of stale inline P0/P1 security list now sourced via the block assembly system (#34, #69)
+- Default Aider model bumped to `claude-sonnet-4-6` (current Sonnet 4.6 family alias) (#70)
 - Restructured `CHANGELOG.md` with versioned release sections
+
+### Fixed
+
+- `standards-review` composite GitHub Action failed to load in consumer repos with `could not find expected ':'` YAML parse error. A Python heredoc inside a `run: |` block was indented at column 0, terminating the YAML literal block scalar so the parser interpreted Python as YAML. The formatter is now a sibling `format-results.py` invoked via `${{ github.action_path }}` (#64, #66)
 
 ## [0.5.0] - 2026-03-03
 

--- a/website/src/content/docs/blog/standards-1-1-reliability-and-agent-coverage.md
+++ b/website/src/content/docs/blog/standards-1-1-reliability-and-agent-coverage.md
@@ -5,7 +5,7 @@ authors:
   - name: C65 LLC
 ---
 
-Standards 1.1 is a maintenance-and-maturity release. Most prior posts have been about *adding* something — a new linter, a new skill, a new framework. This release is about the layer underneath: the governance, infrastructure, and drift-prevention that make the project trustworthy as a long-running dependency.
+Standards 1.1 is a maintenance-and-maturity release. Most prior posts have been about *adding* something — a new linter, a new skill, a new framework. This release is about the layer underneath: the governance, infrastructure, and drift-prevention that make the project trustworthy as a long-running dependency. It also closes a gap that was overdue: cross-agent coordination conventions for [Google Antigravity](https://antigravity.google.com), so Missions and design-fidelity reviews work the same way whether the agent in front of you is Antigravity, Claude Code, Cursor, Aider, or Codex.
 
 ## Project governance you can grep
 
@@ -51,11 +51,31 @@ The website itself caught up in this release:
 - The build pipeline now **syncs security standards into the rendered docs automatically**, so the website can't drift from the canonical files.
 - The blog backfilled posts covering release history back to 0.1.
 
-## What's next
+## Antigravity Mission isolation
 
-Two scoped successors from the [#9 Antigravity audit](https://github.com/c65llc/coding-standards/issues/9#issuecomment-4253926070) are still in flight:
+[Google Antigravity](https://antigravity.google.com) groups work into Missions — long-running, agent-driven tasks scoped to a feature or fix. The problem when multiple agents touch the same project: Claude Code, Cursor, and Aider have no native concept of an active Mission, so they don't know whether their work is in scope or scope creep.
 
-- [#67 — Antigravity Mission isolation workflow + Postgres MCP](https://github.com/c65llc/coding-standards/issues/67)
-- [#68 — Antigravity browser-agent UI validation protocol + `/assets/designs` convention](https://github.com/c65llc/coding-standards/issues/68)
+1.1 ships a cross-agent advisory mechanism — `.gemini/active_mission.log` — and two helper scripts:
 
-If you're using Google Antigravity in a production context and have opinions on either, the issues are open.
+```bash
+./scripts/mission-set.sh https://antigravity.google.com/missions/<id>   # at start
+./scripts/mission-clear.sh                                              # on completion
+```
+
+Other agents check the log before starting work; if a Mission is active, they reference it in commits and avoid expanding scope. The full convention (feature bracketing, lifecycle, what "stale" looks like — i.e. a non-empty log more than ~7 days old) lives in `proc-04 § 5`, with the read protocol mirrored in `GEMINI.md` so every agent that consumes the standards picks it up automatically.
+
+Alongside it, `.gemini/settings.json` ships a Postgres MCP entry — opt-in via `POSTGRES_MCP_DATABASE_URL` env var. When set, Gemini gets live schema introspection for migration and query work; when unset, the server fails to start gracefully and Gemini continues without it. `make doctor` warns when the entry is present but the env var is missing.
+
+## Browser-agent UI validation
+
+Antigravity, Claude Code (via Playwright MCP), and Cursor all have browser tools that can render and screenshot a UI. Until now there was no convention for *what to compare it against* — agents would render, agree it looked "fine", and merge. 1.1 introduces `assets/designs/` as a per-project reference directory, plus `proc-04 § 7: UI Change Validation` defining the protocol:
+
+1. **Render** via dev server or the project's [Devloop](/standards/process/proc-04_agent_workflow_standards/#4-devloop-pattern-ui-projects) `/rebuild` endpoint.
+2. **Capture** the rendered output with the agent's browser tool.
+3. **Compare** against `assets/designs/<route-or-component>/<state>.png`.
+
+The deliberate non-default: **pixel-diff is not the gate.** Font rendering, anti-aliasing, and sub-pixel layout drift swamp real changes. The agent surfaces the diff (side-by-side, overlay, or per-region delta) and a written summary; a human approves whether the change matches design intent. Pixel-diff gating is opt-in for projects that want to enforce it, with thresholds documented in `assets/designs/NOTES.md`.
+
+The `assets/designs/` directory is **opt-in per project** — `setup.sh` doesn't auto-create it. Projects taking on UI work add it manually and copy in `templates/assets-designs-README.md.example`, which documents naming conventions, common state vocabulary (`default`, `loading`, `error`, `mobile`, `dark`, etc.), and the cross-agent invocation table.
+
+For agents without native browser tools (Aider, Codex), the protocol relies on the project's [Devloop](/standards/process/proc-04_agent_workflow_standards/#4-devloop-pattern-ui-projects) `GET /snapshot` HTTP endpoint to normalize capture across all agents.

--- a/website/src/content/docs/blog/standards-1-1-reliability-and-agent-coverage.md
+++ b/website/src/content/docs/blog/standards-1-1-reliability-and-agent-coverage.md
@@ -1,0 +1,61 @@
+---
+title: "Standards 1.1: Reliability and Agent Coverage"
+date: 2026-04-15
+authors:
+  - name: C65 LLC
+---
+
+Standards 1.1 is a maintenance-and-maturity release. Most prior posts have been about *adding* something — a new linter, a new skill, a new framework. This release is about the layer underneath: the governance, infrastructure, and drift-prevention that make the project trustworthy as a long-running dependency.
+
+## Project governance you can grep
+
+Three files most projects don't notice until they're missing:
+
+- **`.github/CODEOWNERS`** — default code ownership for review routing. Aligns with [proc-03 code review expectations](/standards/process/proc-03_code_review_expectations/).
+- **`.github/dependabot.yml`** — automated dependency updates for npm and GitHub Actions. This is distinct from the [72-hour age gate](/blog/dependency-age-gate/): dependabot *proposes* upgrades, the age gate *decides* whether they're old enough to install.
+- **A P0/P1/P2 checklist in the PR template.** The [security framework](/blog/security-standards/) defined the severity model; the PR template is where reviewers and authors actually use it. One short checklist beats a 200-line standards doc no one re-reads per PR.
+
+## Why decisions are written down
+
+`docs/adr/0001-unified-standards-repository.md` is the first Architecture Decision Record in the repo. It captures *why* the standards live in one repo per organization (rather than per-language or per-team) and what the alternatives were. ADRs aren't documentation in the usual sense; they're the trail of receipts for choices that later look obvious.
+
+Two new READMEs join it: `standards/README.md` (a map of the directory layout and naming conventions) and `bin/README.md` (an overview of the `gh-task` CLI with links to its full guide). Neither adds anything functionally new; both compress the time-to-orient for someone landing in the repo cold.
+
+## Drift detection for the .aiderrc file
+
+When the [block-based agent config assembly](/blog/token-efficient-agent-configs/) shipped, every agent config file *except one* was migrated to it. The exception was `.aiderrc` — `sync-standards.sh` treats it as customized (its checksum diverged from the canonical template) and skipped it on every sync. The result: that file carried a 97-line inline P0/P1 security list that the rest of the project had stopped using six weeks earlier ([#34](https://github.com/c65llc/coding-standards/issues/34)).
+
+1.1 resyncs `.aiderrc` to its canonical template and adds a new `make doctor` check — `check_aiderrc_template_sync` — that `cmp -s` compares the two files and surfaces drift before another six weeks pass. Fix is small; the generalizable lesson is bigger: when you build an assembly system, audit the files that *aren't* in it.
+
+The default Aider model also moves from `claude-sonnet-4-20250514` (a dated Sonnet 4.0 preview) to the family alias `claude-sonnet-4-6`, which auto-tracks point releases without requiring further template churn.
+
+## Reliability fix: the standards-review action
+
+The [standards-review composite action](/blog/pr-review-bot/) failed to load in consumer repos with:
+
+```
+while scanning a simple key
+could not find expected ':' (line 91, col 1)
+```
+
+Root cause: a Python heredoc inside a `run: |` block was indented at column 0. YAML's literal block scalar terminates the moment a content line has less indentation than the block, so the parser ended the scalar at the first heredoc line and tried to interpret Python as YAML. It choked on the colon in `if len(sys.argv) > 1 else "{}"`.
+
+The fix moves the formatter to a sibling `format-results.py` invoked via `${{ github.action_path }}`. The YAML stays trivial, and the Python is independently testable. Two-file change ([#64](https://github.com/c65llc/coding-standards/issues/64)).
+
+## Website surface area
+
+The website itself caught up in this release:
+
+- A **"How It Works"** page covering the architecture and the standards-sync pipeline end-to-end — useful for anyone evaluating the project before adopting it.
+- A **Security section in the sidebar**, surfacing `sec-01` rather than burying it under "Standards".
+- The build pipeline now **syncs security standards into the rendered docs automatically**, so the website can't drift from the canonical files.
+- The blog backfilled posts covering release history back to 0.1.
+
+## What's next
+
+Two scoped successors from the [#9 Antigravity audit](https://github.com/c65llc/coding-standards/issues/9#issuecomment-4253926070) are still in flight:
+
+- [#67 — Antigravity Mission isolation workflow + Postgres MCP](https://github.com/c65llc/coding-standards/issues/67)
+- [#68 — Antigravity browser-agent UI validation protocol + `/assets/designs` convention](https://github.com/c65llc/coding-standards/issues/68)
+
+If you're using Google Antigravity in a production context and have opinions on either, the issues are open.


### PR DESCRIPTION
## Summary

Pre-stages release docs for **Standards 1.1**. Per scoping discussion: bundles all previously-unannounced `[Unreleased]` items into 1.1 along with the milestone's three PRs (#66, #69, #70). Items already covered by prior blog posts are linked rather than re-explained.

## What's in 1.1 (per the post)

| Bucket | Items |
|---|---|
| Project governance | `.github/CODEOWNERS`, `.github/dependabot.yml`, P0/P1/P2 PR-template checklist |
| Architecture & docs | `docs/adr/0001-...`, `standards/README.md`, `bin/README.md` |
| Website | "How It Works" page, sidebar Security section, security build-pipeline sync, blog history backfill |
| Reliability fixes | #66 (standards-review YAML heredoc fix), #69 (.aiderrc resync + drift check), #70 (Aider model → claude-sonnet-4-6) |

## Files changed

- `CHANGELOG.md` + `docs/changelog.md` — `[Unreleased]` → `[1.1.0] - 2026-04-15`. Empty `[Unreleased]` kept above for next cycle.
- `website/src/content/docs/blog/standards-1-1-reliability-and-agent-coverage.md` — new blog post (~60 lines, ~1100 words).

## Editorial choices

- **No re-documenting prior posts.** Where 1.1 builds on already-blogged systems (block assembly, standards-review action, security framework, dependency age gate), the post links to those posts and only describes what's new.
- **Date is 2026-04-15** — accurate to the docs creation date. Bump at merge time if 1.1 ships later.
- **`[Unreleased]` retained but empty** above 1.1.0 — ready for the next accumulation cycle.

## Merge order

This PR should merge **after** #66, #69, #70 — otherwise the changelog claims the action.yml fix etc. are shipped while they're still in flight. None of the PRs conflict; only the merge timing matters.

## Test plan

- [ ] Reviewer reads the blog post end-to-end and confirms no re-documenting of prior posts
- [ ] Reviewer confirms the changelog accurately captures shipped 1.1 scope
- [ ] Website preview build succeeds (Starlight blog plugin auto-registers the new post — no sidebar config touch needed)