### PR TITLE
feat(antigravity): Mission isolation workflow + Postgres MCP

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -159,7 +159,7 @@ Full convention (feature bracketing, lifecycle, what "stale" looks like) is docu
 export POSTGRES_MCP_DATABASE_URL="postgresql://user:pass@host:5432/dbname"
 ```
 
-When the env var is unset, the MCP server fails to start and Gemini continues without it (the `npx -y @modelcontextprotocol/server-postgres` invocation requires a connection string). When set, Gemini gains live introspection of your schema for migration validation, query writing, and constraint checks.
+When the env var is unset, the MCP server's launcher exits cleanly (`exit 0`) and Gemini continues without it. The launcher is a `sh -lc` wrapper that conditionally execs `npx -y @modelcontextprotocol/server-postgres` only when `POSTGRES_MCP_DATABASE_URL` is non-empty — robust across Gemini CLI versions that may or may not natively expand `${...}` inside JSON args. When set, Gemini gains live introspection of your schema for migration validation, query writing, and constraint checks.
 
 **Remove the entire `"postgres"` block from `.gemini/settings.json`** if your project does not use Postgres. Future Gemini parser versions may reject unreachable MCP servers more strictly.
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -123,11 +123,45 @@ When working with this repository, agents must follow the A-P-E (Analyze, Plan, 
 When starting work on this repository:
 
 1. Read `.gemini/GEMINI.md` (this file) to understand architecture and constraints
-2. Review `standards/architecture/arch-01_project_standards_and_architecture.md` for core principles
-3. Check `.cursorrules` for Cursor AI integration patterns
-4. Use checkpointing via Gemini CLI before attempting any refactors
-5. Do not proceed with multi-file edits without first outputting a 'Proposed Logic Plan'
-6. Verify changes don't break existing integrations
+2. **Check for an active Antigravity Mission** — see "Active Mission Tracking" below
+3. Review `standards/architecture/arch-01_project_standards_and_architecture.md` for core principles
+4. Check `.cursorrules` for Cursor AI integration patterns
+5. Use checkpointing via Gemini CLI before attempting any refactors
+6. Do not proceed with multi-file edits without first outputting a 'Proposed Logic Plan'
+7. Verify changes don't break existing integrations
+
+## 🚀 Active Mission Tracking
+
+**Read protocol for all agents (Claude Code, Cursor, Aider, Codex, Gemini):**
+
+Before starting work in this repo, check whether an Antigravity Mission is in flight:
+
+```bash
+[ -s .gemini/active_mission.log ] && head -1 .gemini/active_mission.log
+```
+
+If a Mission URL is present, you are working under that Mission's scope. Reference it in commit messages and avoid scope creep beyond its stated goals. If the file is empty or absent, no Mission is active — proceed under standard issue/PR tracking.
+
+**Set/clear the Mission** with the helper scripts:
+
+```bash
+./scripts/mission-set.sh https://antigravity.google.com/missions/<id>   # at start
+./scripts/mission-clear.sh                                              # on completion
+```
+
+Full convention (feature bracketing, lifecycle, what "stale" looks like) is documented in `standards/process/proc-04_agent_workflow_standards.md` § 5.
+
+## 🐘 Postgres MCP (opt-in)
+
+`.gemini/settings.json` ships a `postgres` MCP server entry that gives Gemini real-time schema validation during database work. It is **opt-in via env var**:
+
+```bash
+export POSTGRES_MCP_DATABASE_URL="postgresql://user:pass@host:5432/dbname"
+```
+
+When the env var is unset, the MCP server fails to start and Gemini continues without it (the `npx -y @modelcontextprotocol/server-postgres` invocation requires a connection string). When set, Gemini gains live introspection of your schema for migration validation, query writing, and constraint checks.
+
+**Remove the entire `"postgres"` block from `.gemini/settings.json`** if your project does not use Postgres. Future Gemini parser versions may reject unreachable MCP servers more strictly.
 
 ## 📝 Change Workflow
 

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -9,8 +9,11 @@
       "trust": true
     },
     "postgres": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-postgres", "${POSTGRES_MCP_DATABASE_URL}"],
+      "command": "sh",
+      "args": [
+        "-lc",
+        "if [ -n \"${POSTGRES_MCP_DATABASE_URL:-}\" ]; then exec npx -y @modelcontextprotocol/server-postgres \"$POSTGRES_MCP_DATABASE_URL\"; else exit 0; fi"
+      ],
       "trust": true
     }
   }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -7,6 +7,11 @@
       "command": "gcloud",
       "args": ["components", "mcp-server"],
       "trust": true
+    },
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres", "${POSTGRES_MCP_DATABASE_URL}"],
+      "trust": true
     }
   }
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -399,12 +399,40 @@ check_aiderrc_template_sync() {
 
 check_postgres_mcp() {
     local settings="$PROJECT_ROOT/.gemini/settings.json"
-    [ ! -f "$settings" ] && return  # No gemini settings — skip
+    if [ ! -f "$settings" ]; then
+        check_pass "Postgres MCP" "No .gemini/settings.json; check skipped"
+        return
+    fi
 
-    # Cheap detection: grep for "postgres" key in mcpServers. We don't parse
-    # JSON here to avoid a jq/python hard dependency for a nice-to-have check.
-    if ! grep -q '"postgres"' "$settings" 2>/dev/null; then
-        return  # Postgres MCP not configured — nothing to verify
+    # Detect "postgres" specifically as a key under mcpServers. Use python3
+    # for accuracy when available (handles arbitrary nesting / whitespace);
+    # fall back to a tightened grep otherwise.
+    local has_postgres="false"
+    if command -v python3 >/dev/null 2>&1; then
+        if python3 -c "
+import json, sys
+try:
+    cfg = json.load(open('$settings'))
+except Exception:
+    sys.exit(1)
+sys.exit(0 if 'postgres' in cfg.get('mcpServers', {}) else 1)
+" 2>/dev/null; then
+            has_postgres="true"
+        fi
+    else
+        # Fallback: collapse whitespace, then anchor pattern to mcpServers
+        # block. Imperfect (won't survive deeply nested mcpServers values
+        # containing the literal "postgres" elsewhere) but better than a
+        # bare grep.
+        if tr -d '\n\r' < "$settings" 2>/dev/null | \
+            grep -qE '"mcpServers"[[:space:]]*:[[:space:]]*\{[^{}]*"postgres"[[:space:]]*:'; then
+            has_postgres="true"
+        fi
+    fi
+
+    if [ "$has_postgres" = "false" ]; then
+        check_pass "Postgres MCP" "Postgres MCP not configured; check skipped"
+        return
     fi
 
     if [ -n "${POSTGRES_MCP_DATABASE_URL:-}" ]; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -394,7 +394,29 @@ check_aiderrc_template_sync() {
 }
 
 # ---------------------------------------------------------------------------
-# Check 8: .gitignore entries
+# Check 8: Postgres MCP env var (if Postgres MCP is configured)
+# ---------------------------------------------------------------------------
+
+check_postgres_mcp() {
+    local settings="$PROJECT_ROOT/.gemini/settings.json"
+    [ ! -f "$settings" ] && return  # No gemini settings — skip
+
+    # Cheap detection: grep for "postgres" key in mcpServers. We don't parse
+    # JSON here to avoid a jq/python hard dependency for a nice-to-have check.
+    if ! grep -q '"postgres"' "$settings" 2>/dev/null; then
+        return  # Postgres MCP not configured — nothing to verify
+    fi
+
+    if [ -n "${POSTGRES_MCP_DATABASE_URL:-}" ]; then
+        check_pass "Postgres MCP" "POSTGRES_MCP_DATABASE_URL is set"
+    else
+        check_warn "Postgres MCP" "Postgres MCP entry present but POSTGRES_MCP_DATABASE_URL unset" \
+            "Set: export POSTGRES_MCP_DATABASE_URL=postgresql://...  (or remove the postgres block from .gemini/settings.json)"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Check 9: .gitignore entries
 # ---------------------------------------------------------------------------
 
 check_gitignore() {
@@ -440,6 +462,7 @@ check_languages
 check_submodule
 check_git_hooks
 check_aiderrc_template_sync
+check_postgres_mcp
 check_gitignore
 
 # ---------------------------------------------------------------------------

--- a/scripts/mission-clear.sh
+++ b/scripts/mission-clear.sh
@@ -8,18 +8,16 @@
 # Usage:
 #   ./scripts/mission-clear.sh
 
-set -e
+set -euo pipefail
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 LOG_FILE="$PROJECT_ROOT/.gemini/active_mission.log"
 
-if [ ! -f "$LOG_FILE" ]; then
-    echo "No active Mission to clear (log file missing): $LOG_FILE"
-    exit 0
-fi
-
-# Truncate rather than delete: keeps the path stable for readers, and the
-# file is gitignored anyway. An empty file = no active Mission.
+# Ensure the parent directory exists, then truncate (or create empty).
+# Truncate rather than delete: keeps the path stable so readers
+# (other agents checking for an active Mission) never error on missing
+# file. An empty file unambiguously means "no active Mission".
+mkdir -p "$(dirname "$LOG_FILE")"
 : > "$LOG_FILE"
 
 echo "✅ Active Mission cleared: $LOG_FILE"

--- a/scripts/mission-clear.sh
+++ b/scripts/mission-clear.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Clear the active Antigravity Mission for the current project.
+#
+# Truncates .gemini/active_mission.log to empty (preserves the file path
+# so subsequent reads return cleanly) and signals to other agents that no
+# Mission is in flight.
+#
+# Usage:
+#   ./scripts/mission-clear.sh
+
+set -e
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOG_FILE="$PROJECT_ROOT/.gemini/active_mission.log"
+
+if [ ! -f "$LOG_FILE" ]; then
+    echo "No active Mission to clear (log file missing): $LOG_FILE"
+    exit 0
+fi
+
+# Truncate rather than delete: keeps the path stable for readers, and the
+# file is gitignored anyway. An empty file = no active Mission.
+: > "$LOG_FILE"
+
+echo "✅ Active Mission cleared: $LOG_FILE"

--- a/scripts/mission-set.sh
+++ b/scripts/mission-set.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Set the active Antigravity Mission for the current project.
+#
+# Writes the Mission URL to .gemini/active_mission.log so other agents
+# (Claude Code, Cursor, Aider, Codex) can read it and stay aligned with
+# the in-flight Mission's scope.
+#
+# Usage:
+#   ./scripts/mission-set.sh <mission-url>
+#
+# Example:
+#   ./scripts/mission-set.sh https://antigravity.google.com/missions/abc123
+
+set -e
+
+MISSION_URL="${1:-}"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOG_FILE="$PROJECT_ROOT/.gemini/active_mission.log"
+
+if [ -z "$MISSION_URL" ]; then
+    echo "Usage: $(basename "$0") <mission-url>" >&2
+    echo "Example: $(basename "$0") https://antigravity.google.com/missions/abc123" >&2
+    exit 1
+fi
+
+# URL validation: must be HTTPS. We deliberately do NOT pin to a specific
+# host pattern — Antigravity's URL scheme may evolve, and consumers may use
+# self-hosted variants. HTTPS-only is the security-relevant invariant.
+if [[ ! "$MISSION_URL" =~ ^https:// ]]; then
+    echo "ERROR: Mission URL must use HTTPS (got: $MISSION_URL)" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# Atomic write: stage in temp file, then move. Avoids partial reads from
+# concurrent agents.
+TMPFILE="$(mktemp "${LOG_FILE}.XXXXXX")"
+trap 'rm -f "$TMPFILE"' EXIT
+{
+    echo "$MISSION_URL"
+    echo "# Set: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$TMPFILE"
+mv "$TMPFILE" "$LOG_FILE"
+trap - EXIT
+
+echo "✅ Active Mission set: $MISSION_URL"
+echo "   Logged to: $LOG_FILE"
+echo ""
+echo "Other agents (Claude Code, Cursor, Aider, Codex) will read this file"
+echo "to stay aligned with the in-flight Mission. Run mission-clear.sh when done."

--- a/scripts/mission-set.sh
+++ b/scripts/mission-set.sh
@@ -11,7 +11,7 @@
 # Example:
 #   ./scripts/mission-set.sh https://antigravity.google.com/missions/abc123
 
-set -e
+set -euo pipefail
 
 MISSION_URL="${1:-}"
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"

--- a/standards/process/proc-04_agent_workflow_standards.md
+++ b/standards/process/proc-04_agent_workflow_standards.md
@@ -150,7 +150,41 @@ setup-devloop: ## Install devloop dependencies
 devloop:       ## Start devloop HTTP server for agent-driven UI iteration
 ```
 
-## 5. Agent-Generated Artifacts
+## 5. Mission Isolation (Antigravity)
+
+When an agent (typically [Google Antigravity](https://antigravity.google.com)) starts work on a major feature, it sets the active Mission URL in `.gemini/active_mission.log`. Other agents (Claude Code, Cursor, Aider, Codex, Gemini CLI) read this file and stay aligned with the Mission's scope.
+
+### Feature Bracketing
+
+* **One Mission per major feature.** Don't lump multiple features into one Mission — the cost is review confusion and Mission scope drift.
+* **Cross-reference issue/PR.** The Mission URL should resolve to a Mission that links the work back to a GitHub Issue or PR.
+* **Don't run two Missions in the same project simultaneously** — they will overwrite each other's `active_mission.log`.
+
+### Lifecycle
+
+```bash
+./scripts/mission-set.sh https://antigravity.google.com/missions/<id>   # at start
+./scripts/mission-clear.sh                                              # on completion
+```
+
+| Phase | Action |
+|-------|--------|
+| **Set** | Before the first agent action on the feature. Validates HTTPS-only, writes URL + UTC timestamp atomically. |
+| **Active** | Other agents reading `.gemini/active_mission.log` will see the URL on first line; treat as authoritative scope. |
+| **Clear** | Immediately on completion — PR merge, Mission close, or abandonment. Do not leave stale entries. |
+| **Stale** | A non-empty `active_mission.log` whose timestamp is more than ~7 days old. Treat as forgotten clear; verify with the Mission owner before assuming it's still valid. |
+
+### Read Protocol
+
+Before starting work in a project, agents SHOULD check the file:
+
+```bash
+[ -s .gemini/active_mission.log ] && head -1 .gemini/active_mission.log
+```
+
+If a Mission URL is present, agents SHOULD reference it in commit messages and PR descriptions. Scope creep beyond the Mission's stated goals SHOULD trigger a new issue rather than expanded edits.
+
+## 6. Agent-Generated Artifacts
 
 ### Commit Conventions
 


### PR DESCRIPTION
Closes #67.

## Summary

Implements the Mission isolation workflow and adds Postgres MCP integration. Splits out from the original [#9 Antigravity audit](https://github.com/c65llc/coding-standards/issues/9#issuecomment-4253926070).

## Two pieces

### 1. Mission isolation

| Artifact | Purpose |
|---|---|
| `scripts/mission-set.sh <url>` | Atomic write of Mission URL + UTC timestamp to `.gemini/active_mission.log`. HTTPS-only validation. Cross-agent advisory. |
| `scripts/mission-clear.sh` | Truncates the log on completion. Preserves the path so reads never error. |
| `proc-04 § 5: Mission Isolation` | Feature-bracketing rules, lifecycle table (set / active / clear / stale), read protocol. Renumbers the prior § 5 (Agent-Generated Artifacts) to § 6. |
| `GEMINI.md > Active Mission Tracking` | Read protocol all agents follow (Claude Code, Cursor, Aider, Codex, Gemini) before starting work in a project. |

### 2. Postgres MCP integration

| Artifact | Purpose |
|---|---|
| `.gemini/settings.json` | Opt-in `postgres` MCP server entry, gated by `POSTGRES_MCP_DATABASE_URL` env var. Fails to start gracefully if unset; Gemini continues without it. |
| `GEMINI.md > Postgres MCP (opt-in)` | When to enable, how to set the env var, when to remove the block (projects without Postgres). |
| `scripts/doctor.sh > check_postgres_mcp` | Detects the entry in `.gemini/settings.json`, warns if env var unset, PASS otherwise. Cheap grep — avoids hard jq/python dependency. |

## Design choices worth flagging

- **HTTPS-only Mission URL validation** — deliberately permissive on host pattern (Antigravity's URL scheme may evolve, consumers may use self-hosted variants). HTTPS is the security-relevant invariant.
- **Truncate-don't-delete** for `active_mission.log` — keeps the path stable for readers; an empty file unambiguously means "no Mission".
- **`_comment` field rejected** — initial settings.json draft used `"_comment"` for inline docs; removed to keep strict-JSON-validator-clean. Docs live in GEMINI.md instead.
- **proc-04 section renumber** — new § 5 is "Mission Isolation"; previous § 5 (Agent-Generated Artifacts) becomes § 6. No external references found via grep.

## Verification

- ✅ `bash -n` on all three scripts (mission-set, mission-clear, doctor)
- ✅ `python3 -m json.tool .gemini/settings.json` clean
- ✅ `mission-set.sh` smoke tests:
  - Valid HTTPS → log written with timestamp
  - HTTP → `ERROR: Mission URL must use HTTPS` + exit 1
  - No args → usage + exit 1
- ✅ `mission-clear.sh` → truncates to 0 bytes, preserves path
- ✅ `check_postgres_mcp` negative path (env unset) → WARN
- ✅ `check_postgres_mcp` positive path (env set) → PASS
- ✅ `make test-scripts` green

## Test plan

- [ ] CI passes
- [ ] Reviewer confirms the proc-04 § 5 / § 6 renumber doesn't break any internal references they're aware of
- [ ] Reviewer confirms the `${POSTGRES_MCP_DATABASE_URL}` env-var expansion is supported by their Gemini CLI version (Gemini ≥ 0.x; revisit if not)