### PR TITLE
feat(antigravity): browser-agent UI validation protocol

### DIFF
--- a/standards/process/proc-04_agent_workflow_standards.md
+++ b/standards/process/proc-04_agent_workflow_standards.md
@@ -217,6 +217,61 @@ Agents MUST create GitHub Issues (or the project's configured tracker) when they
 
 **Agents must NOT silently defer work.** If something needs to be done, it needs to be tracked. Check `CLAUDE.md`, `README.md`, or `.github/CONTRIBUTING.md` for the project's configured tracking tool. Default is GitHub Issues.
 
+## 7. UI Change Validation
+
+For projects with a graphical interface, agents that modify UI files MUST validate the rendered output against a reference design before claiming the change is complete. This complements the [Devloop Pattern](#4-devloop-pattern-ui-projects) — devloop enables agents to *iterate*; UI Change Validation enforces that the iteration converges on design intent.
+
+### When the protocol triggers
+
+Agents SHOULD apply this protocol when modifying any of the following file extensions:
+
+| Stack | Extensions |
+|---|---|
+| Web | `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`, `*.html`, `*.css`, `*.scss` |
+| Mobile / desktop | `*.dart`, `*.swift`, `*.kt` (Compose), `*.xaml` |
+| Style tokens | `tokens.json`, `theme.*`, design-system source files |
+
+For changes that don't trip a heuristic (e.g., copy edits in a Markdown-driven CMS), the PR author MAY opt in by writing `ui-validation: required` in the PR body.
+
+### The three-step workflow
+
+1. **Render.** Spin up the dev server (or use the project's `/rebuild` devloop endpoint).
+2. **Capture.** Take a screenshot of the changed surface using the agent's browser tool — see "Cross-agent invocation" below.
+3. **Compare.** Diff the screenshot against the reference design in `assets/designs/<route-or-component>/<state>.png`.
+
+### Comparison criteria
+
+**The agent surfaces the diff; a human approves whether intent is met.** Pixel-diff alone is not gating: font rendering, anti-aliasing, sub-pixel layout, and OS-level smoothing produce noise that swamps real design changes. Use one of:
+
+- **Side-by-side**: reference and rendered output adjacent. Best for layout-driven changes.
+- **Overlay**: rendered output 50% opacity over reference. Best for spacing and alignment.
+- **Per-region delta**: cropped diffs for changed components only. Best for token / theme changes that touch many pages.
+
+The agent's output is a **diff artifact + a summary of what changed**. Approval is human-gated unless the project explicitly opts into pixel-diff gating (rare; document the threshold in `assets/designs/NOTES.md`).
+
+### Cross-agent invocation
+
+| Agent | Browser tool |
+|---|---|
+| Google Antigravity | Built-in Browser Agent |
+| Claude Code | Playwright MCP server (`@modelcontextprotocol/server-playwright`) |
+| Cursor | Built-in browser tool |
+| Aider, Codex | No native browser — projects exposing the [Devloop](#4-devloop-pattern-ui-projects) `GET /snapshot` endpoint normalize this across all agents |
+
+### `assets/designs/` directory convention
+
+Reference designs live in `assets/designs/<route-or-component>/<state>.{png,svg}`. Each project SHOULD include a copy of the [`templates/assets-designs-README.md.example`](https://github.com/c65llc/coding-standards/blob/main/templates/assets-designs-README.md.example) template at `assets/designs/README.md` to document its specific naming conventions and breakpoint coverage.
+
+The directory is **opt-in per project** — `setup.sh` does not auto-create it. Add it manually when the project takes on UI work.
+
+### Updating the reference
+
+When design intent changes (designer ships a new mock, accessibility audit changes spacing, etc.):
+
+1. Update the reference in the same PR as the UI change.
+2. Note the intentional reference change in the PR body so reviewers know the diff is expected.
+3. Update `assets/designs/NOTES.md` if the change requires explanation (e.g., "Reduced primary CTA size to meet WCAG 2.5.5 target-size requirements").
+
 ## Context Handling Across Layers
 
 When agent work spans multiple architectural layers:

--- a/standards/process/proc-04_agent_workflow_standards.md
+++ b/standards/process/proc-04_agent_workflow_standards.md
@@ -223,15 +223,15 @@ For projects with a graphical interface, agents that modify UI files MUST valida
 
 ### When the protocol triggers
 
-Agents SHOULD apply this protocol when modifying any of the following file extensions:
+Agents SHOULD apply this protocol when modifying files matching any of the following patterns:
 
-| Stack | Extensions |
+| Stack | Patterns (globs) |
 |---|---|
-| Web | `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`, `*.html`, `*.css`, `*.scss` |
-| Mobile / desktop | `*.dart`, `*.swift`, `*.kt` (Compose), `*.xaml` |
-| Style tokens | `tokens.json`, `theme.*`, design-system source files |
+| Web | `**/*.tsx`, `**/*.jsx`, `**/*.vue`, `**/*.svelte`, `**/*.html`, `**/*.css`, `**/*.scss` |
+| Mobile / desktop | `**/*.dart`, `**/*.swift`, `**/*.kt` (Compose), `**/*.xaml` |
+| Style tokens / theme | `**/tokens.json`, `**/theme.*`, `**/design-tokens/**`, `**/*.tokens.{json,yml,yaml}` |
 
-For changes that don't trip a heuristic (e.g., copy edits in a Markdown-driven CMS), the PR author MAY opt in by writing `ui-validation: required` in the PR body.
+Patterns are globs evaluated against repo-relative file paths. For changes that don't trip a pattern (e.g., copy edits in a Markdown-driven CMS that affect rendered UI), the PR author MAY opt in by writing `ui-validation: required` in the PR body.
 
 ### The three-step workflow
 

--- a/standards/shared/blocks/role-app.md
+++ b/standards/shared/blocks/role-app.md
@@ -7,3 +7,4 @@ Prefer `const` constructors and stateless components when possible.
 Touch targets: 44×44pt minimum (iOS), 48×48dp (Android). All interactive elements need accessible labels.
 Support keyboard navigation. Ensure focus order is logical. Maintain WCAG AA color contrast (4.5:1 normal text).
 Avoid synchronous work on the main/UI thread. Paginate or virtualize large lists.
+UI changes MUST be validated against reference designs in `assets/designs/<route-or-component>/<state>.png` — render, screenshot, diff. Human-gated approval; pixel-diff alone is too noisy to gate on. Full protocol in `proc-04 § 7 UI Change Validation`.

--- a/templates/assets-designs-README.md.example
+++ b/templates/assets-designs-README.md.example
@@ -1,0 +1,64 @@
+# `assets/designs/`
+
+Reference designs for UI changes. Agents working on UI files compare their rendered output against these references — see `proc-04 § UI Change Validation` for the full protocol.
+
+## Layout
+
+```
+assets/designs/
+  <route-or-component>/
+    <state>.png            ← canonical reference (PNG preferred for diffability)
+    <state>.svg            ← optional vector source
+    <state>.figma.url      ← single-line file containing the Figma node URL
+    NOTES.md               ← optional: known caveats, design intent, breakpoints
+```
+
+**Naming**:
+
+- `<route-or-component>` matches the path or component name as it appears in the codebase. Examples:
+  - `assets/designs/login-page/` for `/login`
+  - `assets/designs/PrimaryButton/` for a reusable component
+  - `assets/designs/checkout-flow/step-2/` for nested routes
+- `<state>` describes the visual state. Common values:
+  - `default` — initial render, no interaction
+  - `loading`, `error`, `empty` — async states
+  - `mobile`, `tablet`, `desktop` — breakpoint-specific
+  - `hover`, `focus`, `active`, `disabled` — interaction states
+  - `dark` / `light` — theme variants
+
+## What to commit
+
+- ✅ PNG references (the canonical comparison artifact)
+- ✅ SVG sources where available (better diffs when intent changes)
+- ✅ `.figma.url` files pointing back to the source-of-truth Figma node
+- ❌ Do not commit raw `.fig` / `.sketch` files (binary, large, no diff)
+- ❌ Do not commit auto-generated screenshots from the agent's runs (those are output, not reference)
+
+## Workflow
+
+When you change a UI file:
+
+1. Identify the corresponding `assets/designs/<route-or-component>/` directory. If none exists for new UI, create one and add the reference design before merging.
+2. Have the agent render the change (dev server + browser agent — Antigravity Browser, Playwright MCP, or Cursor's built-in browser).
+3. Have the agent screenshot the rendered output and compare against the reference.
+4. **Comparison is human-reviewed.** The agent surfaces the diff (side-by-side, overlay, or per-region delta) and explains what changed. A human approves whether the change matches design intent. Pixel-diff alone is too noisy to gate on (font rendering, anti-aliasing, sub-pixel layout drift).
+
+## When to update the reference
+
+When the design *intent* changes (designer ships a new mock, accessibility audit changes spacing, etc.):
+
+1. Update the reference PNG/SVG/Figma URL in this directory in the same PR as the UI change.
+2. Note the change in the PR body so reviewers know the diff is intentional.
+3. Update `NOTES.md` if the change requires explanation (e.g., "Reduced primary CTA size to meet WCAG 2.5.5 target-size requirements").
+
+## Cross-agent invocation
+
+| Agent | Tool to render + screenshot |
+|---|---|
+| Google Antigravity | Browser Agent (built-in) |
+| Claude Code | Playwright MCP server (`@modelcontextprotocol/server-playwright`) |
+| Cursor | Built-in browser tool |
+| Aider | Manual screenshot + paste; no native browser tool |
+| Codex | Same — manual; project should expose a `/snapshot` HTTP endpoint per `proc-04 § Devloop Pattern` |
+
+Projects exposing the [Devloop Pattern](../standards/process/proc-04_agent_workflow_standards.md) `GET /snapshot` endpoint can normalize this across agents — every agent calls the same HTTP endpoint regardless of its built-in capabilities.

--- a/templates/assets-designs-README.md.example
+++ b/templates/assets-designs-README.md.example
@@ -61,4 +61,4 @@ When the design *intent* changes (designer ships a new mock, accessibility audit
 | Aider | Manual screenshot + paste; no native browser tool |
 | Codex | Same — manual; project should expose a `/snapshot` HTTP endpoint per `proc-04 § Devloop Pattern` |
 
-Projects exposing the [Devloop Pattern](../standards/process/proc-04_agent_workflow_standards.md) `GET /snapshot` endpoint can normalize this across agents — every agent calls the same HTTP endpoint regardless of its built-in capabilities.
+Projects exposing the [Devloop Pattern](https://github.com/c65llc/coding-standards/blob/main/standards/process/proc-04_agent_workflow_standards.md#4-devloop-pattern-ui-projects) `GET /snapshot` endpoint can normalize this across agents — every agent calls the same HTTP endpoint regardless of its built-in capabilities.


### PR DESCRIPTION
Closes #68.

> **Stacked PR.** Base branch is `feat/67-antigravity-mission-workflow` (PR #72), not `main`. PR #72 must merge first; this PR's base will auto-rebase to `main` afterward.

## Summary

Defines the protocol agents follow when modifying UI files: render the change, screenshot it, diff against a reference design in `assets/designs/`. Splits out from the original [#9 Antigravity audit](https://github.com/c65llc/coding-standards/issues/9#issuecomment-4253926070).

## Three artifacts

| File | Purpose |
|---|---|
| `proc-04 § 7: UI Change Validation` | Trigger heuristic, three-step workflow, comparison criteria, cross-agent invocation table, opt-in `assets/designs/` convention |
| `templates/assets-designs-README.md.example` | Reference template projects copy when opting in |
| `standards/shared/blocks/role-app.md` | Single-line UI-validation requirement that flows into every assembled `role: app` agent config (Claude Code, Cursor, Copilot, Gemini, Codex) — gives the protocol cross-agent visibility via the existing block-assembly system rather than touching five base templates |

## Design choices flagged for review

1. **Comparison is human-gated, not pixel-diff gated.** Pixel-diff has too many false positives (font rendering, anti-aliasing, sub-pixel layout drift). The agent's job is to surface the diff (side-by-side / overlay / per-region delta) and a summary of what changed; a human approves intent. Pixel-diff gating is opt-in, documented in `assets/designs/NOTES.md`.
2. **Trigger heuristic is file-extension based**, not keyword-based or path-based. A change to `Button.tsx` triggers the protocol; a change to `BUTTON_SPECS.md` does not. PR authors can manually opt in for non-triggering cases via `ui-validation: required` in the PR body.
3. **`assets/designs/` is opt-in per project**, NOT auto-created by `setup.sh`. Reasoning: most projects don't have UI; auto-creating empty directories would clutter their tree. Projects taking on UI work add it manually + drop in the README template.
4. **Cross-agent visibility via role-app block, not five base-template edits.** The block-assembly system already injects role-app into every assembled config when `role: app`. Adding one line to the block is one edit; touching five base templates is five edits with five drift risks.
5. **Aider + Codex have no native browser tool** — documented as relying on the project's Devloop `GET /snapshot` endpoint (proc-04 § 4) for normalization. This is the path forward rather than building per-agent shims.

## Verification

- ✅ `make test-scripts` green (no script changes)
- ✅ `proc-04` section ordering: 1-7 then "Context Handling" — `grep -n '^## ' standards/process/proc-04_agent_workflow_standards.md` confirms
- ✅ role-app block adds 1 line — assembled configs will include it on next sync

## Test plan

- [ ] CI passes (after #72 merges and this rebases onto main)
- [ ] Reviewer confirms the trigger-heuristic file extensions cover the right surface for our typical projects
- [ ] Reviewer confirms human-gated approval is the right default (vs. pixel-diff opt-in)
- [ ] (Future) Validate end-to-end on a project with UI: drop in `assets/designs/`, modify a component, confirm Antigravity Browser Agent + Claude Code Playwright MCP both produce useful diffs