### PR TITLE
feat: Standards 1.2 safe setup

### DIFF
--- a/.cursor/commands/merge-standards.md
+++ b/.cursor/commands/merge-standards.md
@@ -1,0 +1,18 @@
+---
+description: Merge pending standards updates into agent configs
+---
+
+# merge-standards
+
+Read `.standards-pending/MERGE_PLAN.md` and walk through each pending file.
+
+For each entry:
+
+1. Read `.standards-pending/<file>` and the existing `<file>` at the project root.
+2. If the existing file is empty or missing, move the pending file into place.
+3. Otherwise produce a diff and ask the user: accept new, keep existing, or merge section-by-section.
+4. For any `<!-- TODO(standards): -->` markers, ask for the content (or infer from `package.json` / `Makefile`) and replace before writing.
+5. Update `.standards-checksums` with the new hash.
+6. Delete the pending file.
+
+Finally, delete `.standards-pending/` if empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-16
+
+### Changed — Safe setup (breaking for setup.sh defaults)
+
+- **`setup.sh` no longer clobbers existing agent configs.** Every assembly now routes through `should_assemble()`; customized files are staged as `.standards-pending/<file>` instead of overwritten. Applies to `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`, `AGENTS.md`, `.aider-instructions.md`.
+- **`--agents` defaults to `detect`** (was: install all six). Setup now probes for existing config files (`CLAUDE.md`, `.cursorrules`, etc.) and installs only for agents already in use. Escape hatches: `--agents all`, `--agents claude-code,cursor`, or explicit comma-separated list.
+- **`--workflow` gates the `standards-review.yml` install.** Previously copied unconditionally when missing; now opt-in. When skipped, setup prints the hint: `To install: ./setup.sh --workflow`.
+- **Template variables in `CLAUDE.md` are now resolved.** `{{PROJECT_NAME}}` is filled from `package.json` / `Cargo.toml` / `pyproject.toml` / directory name. `{{PROJECT_OVERVIEW}}` and `{{KEY_COMMANDS}}` are rewritten to `<!-- TODO(standards): -->` markers the merge skill fills in — never shipped as literal `{{...}}`.
+
+### Added
+
+- **`scripts/lib/assembly.sh`** — shared `assemble_agent_config_guarded()` used by both `setup.sh` and `sync-standards.sh`. First-run and re-sync now behave identically.
+- **`scripts/lib/detect-agents.sh`** — `detect_installed_agents()` probe used by `--agents detect`.
+- **`scripts/lib/template-vars.sh`** — `resolve_project_name`, `resolve_template_vars`.
+- **`scripts/lib/merge-plan.sh`** — `write_merge_plan()` emits `.standards-pending/MERGE_PLAN.md`.
+- **`.cursor/commands/merge-standards.md`** — Cursor-facing twin of the Claude Code skill.
+- **`make merge-standards`** — prints `MERGE_PLAN.md` for manual or agent-agnostic workflows.
+- **`scripts/test-setup-safe.sh`** — 17 functional tests for pending-mode writes, agent detection, template-var resolution, workflow gate, MERGE_PLAN emission. Wired into `make test`.
+
+### Fixed
+
+- Re-running `setup.sh` on a project that already has customized `AGENTS.md` / `CLAUDE.md` no longer discards the user's work.
+- Assembled `CLAUDE.md` never ships with literal `{{PROJECT_NAME}}`, `{{PROJECT_OVERVIEW}}`, or `{{KEY_COMMANDS}}` tokens.
+
 ## [1.1.0] - 2026-04-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,4 @@ All bash. Key scripts:
 - **Agent config consistency**: When modifying shared standards in `core-standards.md`, check that agent configs (`.cursorrules`, copilot-instructions.md, `.aiderrc`, `.codexrc`, `GEMINI.md`) stay aligned.
 - **Shell scripts**: Must pass `bash -n` syntax validation.
 - **Safety**: Never modify `.standards_tmp/`, `.secret`, or `.tfstate` files. Always preserve standards file numbering. Update `.cursorrules` when adding new standards.
+- **Safe setup (1.2+)**: `setup.sh` never clobbers existing agent configs. Customized files are staged to `.standards-pending/` with a `MERGE_PLAN.md` describing how to reconcile them. The merge skill (`/merge-standards` in Claude Code / Cursor, `make merge-standards` via CLI) drives the agent-agnostic handoff.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help ls setup sync-standards diff-standards check-standards update-standards setup-agents add-copilot-instructions doctor lint-standards website-dev website-build website-preview test test-scripts test-bootstrap test-gh-task test-setup-safe
+.PHONY: help ls setup sync-standards diff-standards check-standards update-standards setup-agents add-copilot-instructions doctor merge-standards lint-standards website-dev website-build website-preview test test-scripts test-bootstrap test-gh-task test-setup-safe
 
 help: ## Show this help message
 	@echo "Standards Repository Management"
@@ -115,6 +115,13 @@ add-copilot-instructions: ## Create PR to add GitHub Copilot custom instructions
 
 doctor: ## Run standards health check
 	@./scripts/doctor.sh
+
+merge-standards: ## Print the pending merge plan for manual / CLI review
+	@if [ -f .standards-pending/MERGE_PLAN.md ]; then \
+		cat .standards-pending/MERGE_PLAN.md; \
+	else \
+		echo "No pending standards updates. (.standards-pending/MERGE_PLAN.md not found)"; \
+	fi
 
 lint-standards: ## Run standards compliance linter
 	@./scripts/lint-standards.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help ls setup sync-standards diff-standards check-standards update-standards setup-agents add-copilot-instructions doctor lint-standards website-dev website-build website-preview test test-scripts test-bootstrap test-gh-task
+.PHONY: help ls setup sync-standards diff-standards check-standards update-standards setup-agents add-copilot-instructions doctor lint-standards website-dev website-build website-preview test test-scripts test-bootstrap test-gh-task test-setup-safe
 
 help: ## Show this help message
 	@echo "Standards Repository Management"
@@ -88,7 +88,10 @@ test-bootstrap: ## Run functional tests on bootstrap scripts
 test-gh-task: ## Run comprehensive tests on gh-task CLI
 	@./scripts/test-gh-task.sh
 
-test: test-scripts test-bootstrap test-gh-task ## Run all tests
+test-setup-safe: ## Run functional tests on safe-setup behavior (1.2)
+	@./scripts/test-setup-safe.sh
+
+test: test-scripts test-bootstrap test-gh-task test-setup-safe ## Run all tests
 
 setup-agents: ## Setup AI agent configurations (Copilot, Aider, Codex)
 	@if [ -d ".standards" ]; then \

--- a/docs/superpowers/plans/2026-04-16-1.2-safe-setup.md
+++ b/docs/superpowers/plans/2026-04-16-1.2-safe-setup.md
@@ -40,6 +40,7 @@
 ## Task 1: Prep — baseline, version bump, failing test harness
 
 **Files:**
+
 - Create: `scripts/test-setup-safe.sh`
 - Modify: `Makefile` (add `test-setup-safe` target, wire into `test`)
 
@@ -127,6 +128,7 @@ git commit -m "test(setup): scaffold functional test harness for safe-setup (1.2
 ## Task 2: Lift the assembly loop into `scripts/lib/assembly.sh`
 
 **Files:**
+
 - Create: `scripts/lib/assembly.sh`
 - Test: `scripts/test-setup-safe.sh`
 
@@ -249,6 +251,7 @@ git commit -m "feat(lib): shared checksum-guarded assembly helper (1.2)"
 Prove the helper is a drop-in for the existing pattern before changing `setup.sh`.
 
 **Files:**
+
 - Modify: `scripts/sync-standards.sh:180-256` (replace inline guarded-assembly block)
 
 - [ ] **Step 1: Add regression test**
@@ -330,6 +333,7 @@ git commit -m "refactor(sync): use lib/assembly.sh for guarded assembly (1.2)"
 ## Task 4: Route `setup.sh` through the shared helper (fix: clobbered AGENTS.md)
 
 **Files:**
+
 - Modify: `scripts/setup.sh:181-250` (the assembly loop inside `setup_ai_agents`)
 
 - [ ] **Step 1: Write the failing test**
@@ -435,6 +439,7 @@ git commit -m "fix(setup): never clobber existing agent configs — stage to .st
 ## Task 5: Agent detection (fix: configs for unused agents)
 
 **Files:**
+
 - Create: `scripts/lib/detect-agents.sh`
 - Modify: `scripts/setup.sh:175-180` (AGENTS_LIST default)
 
@@ -550,6 +555,7 @@ git commit -m "feat(setup): default --agents detect, only install for agents alr
 ## Task 6: Resolve template vars in CLAUDE.md (fix: unresolved `{{vars}}`)
 
 **Files:**
+
 - Create: `scripts/lib/template-vars.sh`
 - Modify: `scripts/assemble-config.sh` (call resolver before writing output)
 
@@ -680,6 +686,7 @@ git commit -m "fix(assemble): resolve {{PROJECT_NAME}} + mark {{PROJECT_OVERVIEW
 ## Task 7: Gate workflow install behind `--workflow` (fix: competing workflow)
 
 **Files:**
+
 - Modify: `scripts/setup.sh:489-502`
 
 - [ ] **Step 1: Write the failing test**
@@ -762,6 +769,7 @@ git commit -m "feat(setup): gate standards-review workflow install behind --work
 ## Task 8: Emit `MERGE_PLAN.md` when pending files exist
 
 **Files:**
+
 - Create: `scripts/lib/merge-plan.sh`
 - Modify: `scripts/setup.sh` (call `write_merge_plan` after `setup_ai_agents` returns)
 
@@ -908,6 +916,7 @@ git commit -m "feat(setup): emit .standards-pending/MERGE_PLAN.md for preferred-
 ## Task 9: Agent-agnostic merge entry points
 
 **Files:**
+
 - Modify: `standards/agents/claude-code/skills/merge-standards.md` (handle setup-time)
 - Create: `.cursor/commands/merge-standards.md`
 - Modify: `Makefile` (add `merge-standards` target)
@@ -985,6 +994,7 @@ git commit -m "feat(skills): agent-agnostic /merge-standards entry points (1.2)"
 ## Task 10: Changelog, blog post, CLAUDE.md update
 
 **Files:**
+
 - Modify: `CHANGELOG.md`
 - Create: `website/src/content/docs/blog/standards-1-2-safe-setup.md`
 - Modify: `CLAUDE.md` (mention the flow under "Conventions")

--- a/docs/superpowers/plans/2026-04-16-1.2-safe-setup.md
+++ b/docs/superpowers/plans/2026-04-16-1.2-safe-setup.md
@@ -1,0 +1,1147 @@
+# Standards 1.2 — Safe Setup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `setup.sh` from clobbering customized files, installing configs for unused agents, emitting unresolved `{{vars}}`, and silently copying a workflow; replace those with a checksum-guarded pending-mode install that any LLM can finish.
+
+**Architecture:** Lift the assembly loop in `sync-standards.sh` into a shared lib (`scripts/lib/assembly.sh`) that calls the existing `should_assemble` / `write_pending` from `checksums.sh`. Point `setup.sh` at the same lib so first-run and re-sync behave identically. Add an agent-detection helper, a template-var resolver in `assemble-config.sh`, a `--workflow` gate for `standards-review.yml`, and a `.standards-pending/MERGE_PLAN.md` emitter. Ship a Cursor command + `make merge-standards` target so the skill is agent-agnostic.
+
+**Tech Stack:** Bash (scripts), POSIX-compatible tooling (grep, sed, awk, shasum), Markdown (docs + blog), Astro/Starlight (website).
+
+**Branch / Worktree:** `feat/1.2-safe-setup` at `.worktrees/1.2-safe-setup`.
+
+---
+
+## File Structure
+
+### Created
+
+- `scripts/lib/assembly.sh` — shared `assemble_agent_config_guarded()` callable from both `setup.sh` and `sync-standards.sh`.
+- `scripts/lib/template-vars.sh` — `resolve_template_vars()` substitutes `{{PROJECT_NAME}}` from package metadata and rewrites `{{PROJECT_OVERVIEW}}` / `{{KEY_COMMANDS}}` to explicit `<!-- TODO(standards): -->` markers.
+- `scripts/lib/merge-plan.sh` — `write_merge_plan()` emits `.standards-pending/MERGE_PLAN.md` describing each pending file, unresolved vars, detected agents.
+- `scripts/lib/detect-agents.sh` — `detect_installed_agents()` scans project for existing agent config files.
+- `scripts/test-setup-safe.sh` — functional tests for the four rejections plus MERGE_PLAN emission. Registered in `Makefile` under `test-setup-safe`.
+- `.cursor/commands/merge-standards.md` — Cursor-facing version of the Claude skill.
+- `website/src/content/docs/blog/standards-1-2-safe-setup.md` — release blog post.
+
+### Modified
+
+- `scripts/setup.sh` — route assembly through `assembly.sh`; default `--agents detect`; gate workflow install behind `--workflow`; emit MERGE_PLAN when any pending files written.
+- `scripts/sync-standards.sh` — switch its internal assembly block to call `assemble_agent_config_guarded()` so both scripts share one code path.
+- `scripts/assemble-config.sh` — call `resolve_template_vars` on every output file.
+- `standards/agents/claude-code/skills/merge-standards.md` — extend to handle setup-time (empty targets, unresolved template vars, missing checksums).
+- `Makefile` — add `merge-standards` (prints MERGE_PLAN) and `test-setup-safe` targets.
+- `CHANGELOG.md` — `[1.2.0]` section.
+- `docs/changelog.md` — mirror CHANGELOG.md entry.
+- `CLAUDE.md` — reference the new safe-setup flow in "Conventions" section.
+
+---
+
+## Task 1: Prep — baseline, version bump, failing test harness
+
+**Files:**
+- Create: `scripts/test-setup-safe.sh`
+- Modify: `Makefile` (add `test-setup-safe` target, wire into `test`)
+
+- [ ] **Step 1: Run baseline tests to confirm clean worktree**
+
+Run: `make test`
+Expected: all existing tests pass (10/10 bootstrap, 12/12 gh-task).
+
+- [ ] **Step 2: Create `scripts/test-setup-safe.sh` with a single failing smoke test**
+
+```bash
+#!/bin/bash
+# Functional tests for Standards 1.2 safe-setup behavior.
+# Each test creates a temp project, runs setup.sh, and asserts outcomes.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETUP="$REPO_ROOT/scripts/setup.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+PASS=0; FAIL=0
+
+TMPDIR_BASE="$(mktemp -d "${TMPDIR:-/tmp}/test-setup-safe.XXXXXX")"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+pass() { echo -e "${GREEN}✓${NC}"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}✗${NC}"; echo "  Error: $1"; FAIL=$((FAIL + 1)); }
+
+make_project() {
+    local name="$1"
+    local dir="$TMPDIR_BASE/$name"
+    mkdir -p "$dir"
+    (cd "$dir" && git init -q && git commit -q --allow-empty -m "init")
+    echo "$dir"
+}
+
+echo -e "${BLUE}Testing Standards 1.2 safe-setup behavior${NC}"
+echo ""
+
+echo -n "Test 1: setup.sh exists and is executable... "
+if [ -x "$SETUP" ]; then pass; else fail "$SETUP not executable"; fi
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "${RED}$FAIL failures${NC}"
+    exit 1
+fi
+echo -e "${GREEN}All $PASS tests passed!${NC}"
+```
+
+- [ ] **Step 3: Make it executable and add Makefile target**
+
+Run: `chmod +x scripts/test-setup-safe.sh`
+
+Then in `Makefile`, after the existing `test-gh-task:` target, add:
+
+```makefile
+test-setup-safe: ## Run functional tests on safe-setup behavior (1.2)
+	@./scripts/test-setup-safe.sh
+```
+
+And extend the aggregate target:
+
+```makefile
+test: test-scripts test-bootstrap test-gh-task test-setup-safe ## Run all tests
+```
+
+Update the `.PHONY` line to include `test-setup-safe`.
+
+- [ ] **Step 4: Run the new target**
+
+Run: `make test-setup-safe`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/test-setup-safe.sh Makefile
+git commit -m "test(setup): scaffold functional test harness for safe-setup (1.2)"
+```
+
+---
+
+## Task 2: Lift the assembly loop into `scripts/lib/assembly.sh`
+
+**Files:**
+- Create: `scripts/lib/assembly.sh`
+- Test: `scripts/test-setup-safe.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/test-setup-safe.sh` before the final summary:
+
+```bash
+echo -n "Test 2: lib/assembly.sh exposes assemble_agent_config_guarded... "
+if bash -c "source '$REPO_ROOT/scripts/lib/assembly.sh' && type assemble_agent_config_guarded" >/dev/null 2>&1; then
+    pass
+else
+    fail "assemble_agent_config_guarded not defined after sourcing lib/assembly.sh"
+fi
+```
+
+- [ ] **Step 2: Run it — confirm it fails**
+
+Run: `make test-setup-safe`
+Expected: FAIL on Test 2 (lib file doesn't exist).
+
+- [ ] **Step 3: Create `scripts/lib/assembly.sh`**
+
+```bash
+#!/bin/bash
+# Shared assembly loop used by setup.sh and sync-standards.sh.
+# Wraps scripts/assemble-config.sh with checksum guarding (should_assemble /
+# write_pending from lib/checksums.sh) so a customized target is staged as a
+# pending update instead of being clobbered.
+
+# Load checksum helpers if not already sourced.
+if ! type should_assemble >/dev/null 2>&1; then
+    _ASM_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck disable=SC1091
+    source "$_ASM_LIB_DIR/checksums.sh"
+fi
+
+# Usage:
+#   assemble_agent_config_guarded <agent> <assemble_script> <blocks_dir> \
+#       <base_template> <output_path> <checksums_path> <dry_run> [block ...]
+#
+# Exit codes:
+#   0 — wrote output (fresh or replacement)
+#   1 — wrote pending update (.standards-pending/)
+#   2 — skipped (manual file without assembly header; backup staged)
+#   3 — assembler failed
+#
+# On exit 0, caller should update its checksums using compute_hash +
+# update_checksum_entry. On exit 1, caller should track the basename in its
+# "pending" accumulator for MERGE_PLAN emission.
+assemble_agent_config_guarded() {
+    local agent="$1"
+    local assemble_script="$2"
+    local blocks_dir="$3"
+    local base_template="$4"
+    local output_path="$5"
+    local checksums_path="$6"
+    local dry_run="$7"
+    shift 7
+    local blocks=("$@")
+
+    if [ "$dry_run" = "true" ]; then
+        if [ -f "$output_path" ]; then
+            echo "  [dry-run] Would assemble (guarded): $output_path"
+        else
+            echo "  [dry-run] Would create: $output_path"
+        fi
+        return 0
+    fi
+
+    local sa_rc=0
+    should_assemble "$output_path" "$checksums_path" || sa_rc=$?
+
+    case "$sa_rc" in
+        0)
+            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+                "$output_path" ${blocks[@]+"${blocks[@]}"}; then
+                return 0
+            else
+                return 3
+            fi
+            ;;
+        1)
+            local tmp
+            tmp=$(mktemp)
+            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+                "$tmp" ${blocks[@]+"${blocks[@]}"} 2>/dev/null; then
+                write_pending "$output_path" "$agent"
+                cp "$tmp" "$PENDING_DIR/$(basename "$output_path")"
+                rm -f "$tmp"
+                return 1
+            else
+                rm -f "$tmp"
+                return 3
+            fi
+            ;;
+        2)
+            return 2
+            ;;
+    esac
+}
+```
+
+- [ ] **Step 4: Run test — confirm pass**
+
+Run: `make test-setup-safe`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/assembly.sh scripts/test-setup-safe.sh
+git commit -m "feat(lib): shared checksum-guarded assembly helper (1.2)"
+```
+
+---
+
+## Task 3: Rewire `sync-standards.sh` to use the shared helper
+
+Prove the helper is a drop-in for the existing pattern before changing `setup.sh`.
+
+**Files:**
+- Modify: `scripts/sync-standards.sh:180-256` (replace inline guarded-assembly block)
+
+- [ ] **Step 1: Add regression test**
+
+Append to `scripts/test-setup-safe.sh`:
+
+```bash
+echo -n "Test 3: sync-standards still passes shellcheck/syntax after refactor... "
+if bash -n "$REPO_ROOT/scripts/sync-standards.sh" 2>/dev/null; then
+    pass
+else
+    fail "sync-standards.sh has syntax errors"
+fi
+
+echo -n "Test 4: sync-standards references assembly lib... "
+if grep -q "lib/assembly.sh" "$REPO_ROOT/scripts/sync-standards.sh"; then
+    pass
+else
+    fail "sync-standards.sh does not source lib/assembly.sh"
+fi
+```
+
+- [ ] **Step 2: Run tests — Test 4 fails, Test 3 passes**
+
+Run: `make test-setup-safe`
+Expected: Test 3 PASS, Test 4 FAIL.
+
+- [ ] **Step 3: Source the lib near the top of `sync-standards.sh`**
+
+Find the existing `source` line for `checksums.sh` (around line 20–40 in `scripts/sync-standards.sh`) and add right after it:
+
+```bash
+if [ -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib/assembly.sh"
+fi
+```
+
+- [ ] **Step 4: Replace the inline guarded-assembly block**
+
+In the loop body (currently `scripts/sync-standards.sh:211-256`), replace the entire `if [ "$DRY_RUN" = true ]; then ... fi` construct with a single call:
+
+```bash
+local rc=0
+assemble_agent_config_guarded \
+    "$agent" "$ASSEMBLE_SCRIPT" "$BLOCKS_DIR" "$BASE_TEMPLATE" \
+    "$OUTPUT_PATH" "$CHECKSUMS_PATH" "$DRY_RUN" \
+    ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"} || rc=$?
+
+case "$rc" in
+    0)
+        echo "✅ $agent config synced"
+        if [ "$DRY_RUN" = false ]; then
+            local new_hash
+            new_hash=$(compute_hash "$OUTPUT_PATH")
+            NEW_CHECKSUMS=$(update_checksum_entry "$(basename "$OUTPUT_PATH")" "$new_hash" "$NEW_CHECKSUMS")
+        fi
+        ;;
+    1) echo "⚠️  $agent config customized — update staged to $PENDING_DIR/" ;;
+    2) echo "⚠️  $agent config was manually created — skipping, backup in $PENDING_DIR/" ;;
+    3) echo "⚠️  Failed to sync $agent config (non-fatal, continuing...)" ;;
+esac
+```
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `make test`
+Expected: all tests pass. The `test-setup-safe` suite now shows 4/4.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/sync-standards.sh scripts/test-setup-safe.sh
+git commit -m "refactor(sync): use lib/assembly.sh for guarded assembly (1.2)"
+```
+
+---
+
+## Task 4: Route `setup.sh` through the shared helper (fix: clobbered AGENTS.md)
+
+**Files:**
+- Modify: `scripts/setup.sh:181-250` (the assembly loop inside `setup_ai_agents`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/test-setup-safe.sh`:
+
+```bash
+echo -n "Test 5: setup.sh preserves pre-existing AGENTS.md (no clobber)... "
+proj=$(make_project "preserve-agents")
+cat > "$proj/AGENTS.md" <<'EOF'
+# My Custom AGENTS.md
+This content must survive setup.sh.
+EOF
+# Stage a fake .standards/ checkout pointing at our repo so setup.sh can find templates.
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+ln -s "$REPO_ROOT/.gemini"   "$proj/.standards/.gemini" 2>/dev/null || true
+(cd "$proj" && "$SETUP" --agents codex --languages typescript >/dev/null 2>&1) || true
+if grep -q "must survive setup.sh" "$proj/AGENTS.md" 2>/dev/null; then
+    pass
+else
+    fail "AGENTS.md was clobbered by setup.sh"
+fi
+if [ -f "$proj/.standards-pending/AGENTS.md" ]; then
+    pass_pending=true
+else
+    pass_pending=false
+fi
+
+echo -n "Test 6: setup.sh stages pending AGENTS.md in .standards-pending/... "
+if [ "$pass_pending" = true ]; then pass; else fail "no pending AGENTS.md written"; fi
+```
+
+- [ ] **Step 2: Run tests — confirm 5 and 6 fail**
+
+Run: `make test-setup-safe`
+Expected: Tests 5 and 6 FAIL (current setup.sh clobbers).
+
+- [ ] **Step 3: Source `lib/assembly.sh` in setup.sh**
+
+Near the existing `source "$SCRIPT_DIR/lib/checksums.sh"` block (around `scripts/setup.sh:82`), add after it:
+
+```bash
+if [ -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib/assembly.sh"
+fi
+```
+
+- [ ] **Step 4: Replace the direct-write block in `setup_ai_agents`**
+
+Find `scripts/setup.sh:208-227` (the `echo "📝 Assembling $agent config..."` through the `else ... continue` block) and replace with:
+
+```bash
+local CHECKSUMS_PATH="$PROJECT_ROOT/$CHECKSUMS_FILE"
+local rc=0
+assemble_agent_config_guarded \
+    "$agent" "$ASSEMBLE_SCRIPT" "$BLOCKS_DIR" "$BASE_TEMPLATE" \
+    "$OUTPUT_PATH" "$CHECKSUMS_PATH" "$DRY_RUN" \
+    ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"} || rc=$?
+
+case "$rc" in
+    0)
+        echo "✅ $agent config assembled"
+        if [ "$DRY_RUN" = false ] && type compute_hash &>/dev/null; then
+            local new_hash
+            new_hash=$(compute_hash "$OUTPUT_PATH")
+            NEW_CHECKSUMS=$(update_checksum_entry "$(basename "$OUTPUT_PATH")" "$new_hash" "$NEW_CHECKSUMS")
+        fi
+        ;;
+    1)
+        echo "⚠️  $agent config already exists and differs — staged to $PENDING_DIR/"
+        PENDING_LIST="${PENDING_LIST:+$PENDING_LIST }$(basename "$OUTPUT_PATH")"
+        ;;
+    2)
+        echo "⚠️  $agent config was manually created — backup in $PENDING_DIR/"
+        PENDING_LIST="${PENDING_LIST:+$PENDING_LIST }$(basename "$OUTPUT_PATH")"
+        ;;
+    3)
+        echo "⚠️  Failed to assemble $agent config (non-fatal, continuing...)"
+        continue
+        ;;
+esac
+```
+
+Initialize `PENDING_LIST=""` at the top of `setup_ai_agents()` (where `ASSEMBLED_AGENTS_LIST` is initialized).
+
+- [ ] **Step 5: Run tests**
+
+Run: `make test`
+Expected: Tests 5 and 6 now pass. 6 total.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/setup.sh scripts/test-setup-safe.sh
+git commit -m "fix(setup): never clobber existing agent configs — stage to .standards-pending/ (1.2)"
+```
+
+---
+
+## Task 5: Agent detection (fix: configs for unused agents)
+
+**Files:**
+- Create: `scripts/lib/detect-agents.sh`
+- Modify: `scripts/setup.sh:175-180` (AGENTS_LIST default)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/test-setup-safe.sh`:
+
+```bash
+echo -n "Test 7: detect-agents returns claude-code when CLAUDE.md exists... "
+proj=$(make_project "detect-claude")
+touch "$proj/CLAUDE.md"
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/detect-agents.sh' && detect_installed_agents '$proj'")
+if echo "$result" | grep -qw "claude-code"; then pass; else fail "got: $result"; fi
+
+echo -n "Test 8: detect-agents returns empty for greenfield project... "
+proj=$(make_project "detect-empty")
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/detect-agents.sh' && detect_installed_agents '$proj'")
+if [ -z "$(echo "$result" | tr -d '[:space:]')" ]; then pass; else fail "got: $result"; fi
+
+echo -n "Test 9: setup.sh --agents detect installs only detected agents... "
+proj=$(make_project "detect-only")
+touch "$proj/CLAUDE.md"
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents detect --languages typescript >/dev/null 2>&1) || true
+if [ ! -f "$proj/.cursorrules" ] && [ ! -f "$proj/.aiderrc" ]; then
+    pass
+else
+    fail "unused-agent configs installed (cursorrules or aiderrc present)"
+fi
+```
+
+- [ ] **Step 2: Run tests — confirm 7, 8, 9 fail**
+
+Run: `make test-setup-safe`
+Expected: all three fail.
+
+- [ ] **Step 3: Create `scripts/lib/detect-agents.sh`**
+
+```bash
+#!/bin/bash
+# Detect which AI agents are already in use in a project by probing for their
+# canonical config files. Called by setup.sh when --agents detect (default).
+# Output: space-separated agent names (claude-code, cursor, copilot, gemini,
+# codex, aider). Empty output = greenfield project.
+
+detect_installed_agents() {
+    local root="${1:-$(pwd)}"
+    local agents=()
+
+    [ -f "$root/CLAUDE.md" ]                         && agents+=("claude-code")
+    [ -f "$root/.cursorrules" ]                      && agents+=("cursor")
+    [ -d "$root/.cursor" ]                           && agents+=("cursor")
+    [ -f "$root/.github/copilot-instructions.md" ]   && agents+=("copilot")
+    [ -f "$root/.gemini/GEMINI.md" ]                 && agents+=("gemini")
+    [ -d "$root/.gemini" ]                           && agents+=("gemini")
+    [ -f "$root/AGENTS.md" ]                         && agents+=("codex")
+    [ -f "$root/.aiderrc" ]                          && agents+=("aider")
+    [ -f "$root/.aider-instructions.md" ]            && agents+=("aider")
+
+    printf '%s\n' "${agents[@]}" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+}
+```
+
+Make it executable: `chmod +x scripts/lib/detect-agents.sh`.
+
+- [ ] **Step 4: Wire `--agents detect` as the default in setup.sh**
+
+Replace `scripts/setup.sh:175-180`:
+
+```bash
+# Determine which agents to set up
+local AGENTS_LIST
+if [ -n "$AGENTS_OVERRIDE" ] && [ "$AGENTS_OVERRIDE" != "detect" ]; then
+    if [ "$AGENTS_OVERRIDE" = "all" ]; then
+        AGENTS_LIST="claude-code cursor copilot gemini codex aider"
+    else
+        AGENTS_LIST=$(echo "$AGENTS_OVERRIDE" | tr ',' ' ')
+    fi
+else
+    # Default: detect agents already in use in the project.
+    if [ -f "$SCRIPT_DIR/lib/detect-agents.sh" ]; then
+        # shellcheck disable=SC1091
+        source "$SCRIPT_DIR/lib/detect-agents.sh"
+        AGENTS_LIST=$(detect_installed_agents "$PROJECT_ROOT")
+    fi
+    if [ -z "$AGENTS_LIST" ]; then
+        echo "ℹ️  No agent configs detected. Pass --agents <list> or --agents all to install."
+        echo "   Detected agents: (none)"
+        echo "   Available: claude-code, cursor, copilot, gemini, codex, aider"
+        AGENTS_LIST=""
+    else
+        echo "ℹ️  Detected agents: $AGENTS_LIST"
+    fi
+fi
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `make test`
+Expected: 9/9 pass in test-setup-safe; full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/detect-agents.sh scripts/setup.sh scripts/test-setup-safe.sh
+git commit -m "feat(setup): default --agents detect, only install for agents already in use (1.2)"
+```
+
+---
+
+## Task 6: Resolve template vars in CLAUDE.md (fix: unresolved `{{vars}}`)
+
+**Files:**
+- Create: `scripts/lib/template-vars.sh`
+- Modify: `scripts/assemble-config.sh` (call resolver before writing output)
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```bash
+echo -n "Test 10: {{PROJECT_NAME}} resolves from package.json... "
+proj=$(make_project "vars-pkg-json")
+cat > "$proj/package.json" <<'EOF'
+{ "name": "acme-widget", "version": "1.0.0" }
+EOF
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/template-vars.sh' && resolve_project_name '$proj'")
+if [ "$result" = "acme-widget" ]; then pass; else fail "got: $result"; fi
+
+echo -n "Test 11: {{PROJECT_NAME}} falls back to directory name... "
+proj=$(make_project "fallback-dirname")
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/template-vars.sh' && resolve_project_name '$proj'")
+if [ "$result" = "fallback-dirname" ]; then pass; else fail "got: $result"; fi
+
+echo -n "Test 12: assembled CLAUDE.md has no literal {{vars}}... "
+proj=$(make_project "no-literal-vars")
+cat > "$proj/package.json" <<'EOF'
+{ "name": "testproj" }
+EOF
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents claude-code --languages typescript >/dev/null 2>&1) || true
+if [ -f "$proj/CLAUDE.md" ] && ! grep -q "{{" "$proj/CLAUDE.md"; then
+    pass
+else
+    fail "CLAUDE.md contains literal {{...}} or was not written"
+fi
+```
+
+- [ ] **Step 2: Run tests — confirm 10, 11, 12 fail**
+
+Run: `make test-setup-safe`
+
+- [ ] **Step 3: Create `scripts/lib/template-vars.sh`**
+
+```bash
+#!/bin/bash
+# Resolve {{PROJECT_NAME}}, {{PROJECT_OVERVIEW}}, {{KEY_COMMANDS}} in
+# assembled agent-config output. Called by assemble-config.sh right before the
+# output file is written.
+#
+# Philosophy: fill what we can from package metadata; replace what we can't
+# with explicit TODO markers so the user (or their LLM via /merge-standards)
+# can finish the job. Never leave literal {{...}} in shipped output.
+
+resolve_project_name() {
+    local root="${1:-$(pwd)}"
+    local name=""
+
+    if [ -f "$root/package.json" ]; then
+        name=$(grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' "$root/package.json" \
+               | head -1 \
+               | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+    fi
+    if [ -z "$name" ] && [ -f "$root/Cargo.toml" ]; then
+        name=$(grep -E '^name[[:space:]]*=' "$root/Cargo.toml" | head -1 \
+               | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/')
+    fi
+    if [ -z "$name" ] && [ -f "$root/pyproject.toml" ]; then
+        name=$(grep -E '^name[[:space:]]*=' "$root/pyproject.toml" | head -1 \
+               | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/')
+    fi
+    if [ -z "$name" ]; then
+        name=$(basename "$root")
+    fi
+    printf '%s' "$name"
+}
+
+# Usage: resolve_template_vars <file> <project_root>
+# Rewrites the file in place.
+resolve_template_vars() {
+    local file="$1"
+    local root="${2:-$(pwd)}"
+    [ -f "$file" ] || return 0
+
+    local project_name
+    project_name=$(resolve_project_name "$root")
+
+    # POSIX-safe in-place edit (macOS/BSD compatible)
+    local tmp
+    tmp=$(mktemp)
+    sed \
+        -e "s|{{PROJECT_NAME}}|${project_name}|g" \
+        -e "s|{{PROJECT_OVERVIEW}}|<!-- TODO(standards): one-paragraph project overview goes here. Run /merge-standards to fill. -->|g" \
+        -e "s|{{KEY_COMMANDS}}|<!-- TODO(standards): list key build/test/run commands. Run /merge-standards to fill. -->|g" \
+        "$file" > "$tmp" && mv "$tmp" "$file"
+}
+```
+
+- [ ] **Step 4: Call the resolver from `assemble-config.sh`**
+
+Near the bottom of `scripts/assemble-config.sh`, after the output is written but before the final success message, add:
+
+```bash
+# Resolve template variables ({{PROJECT_NAME}} etc.) in place.
+_TV_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/template-vars.sh"
+if [ -f "$_TV_LIB" ]; then
+    # shellcheck disable=SC1091
+    source "$_TV_LIB"
+    # Assembler is sometimes invoked from inside a project; prefer that root.
+    _TV_ROOT="$(git -C "$(dirname "$OUTPUT_FILE")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+    resolve_template_vars "$OUTPUT_FILE" "$_TV_ROOT"
+fi
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `make test`
+Expected: 12/12 pass in test-setup-safe.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/template-vars.sh scripts/assemble-config.sh scripts/test-setup-safe.sh
+git commit -m "fix(assemble): resolve {{PROJECT_NAME}} + mark {{PROJECT_OVERVIEW}}/{{KEY_COMMANDS}} as TODO (1.2)"
+```
+
+---
+
+## Task 7: Gate workflow install behind `--workflow` (fix: competing workflow)
+
+**Files:**
+- Modify: `scripts/setup.sh:489-502`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```bash
+echo -n "Test 13: setup.sh does NOT install standards-review.yml by default... "
+proj=$(make_project "no-workflow")
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+ln -s "$REPO_ROOT/.github"   "$proj/.standards/.github"
+ln -s "$REPO_ROOT/templates" "$proj/.standards/templates"
+(cd "$proj" && "$SETUP" --agents claude-code --languages typescript >/dev/null 2>&1) || true
+if [ ! -f "$proj/.github/workflows/standards-review.yml" ]; then pass; else fail "workflow installed without --workflow"; fi
+
+echo -n "Test 14: setup.sh --workflow DOES install standards-review.yml... "
+proj=$(make_project "with-workflow")
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+ln -s "$REPO_ROOT/.github"   "$proj/.standards/.github"
+ln -s "$REPO_ROOT/templates" "$proj/.standards/templates"
+(cd "$proj" && "$SETUP" --agents claude-code --languages typescript --workflow >/dev/null 2>&1) || true
+if [ -f "$proj/.github/workflows/standards-review.yml" ]; then pass; else fail "workflow not installed with --workflow"; fi
+```
+
+- [ ] **Step 2: Run tests — confirm 13 fails (14 may pass accidentally)**
+
+Run: `make test-setup-safe`
+
+- [ ] **Step 3: Add `--workflow` flag parsing**
+
+In the argument-parsing block at `scripts/setup.sh:15-37`, add a new case before the `*)` wildcard:
+
+```bash
+INSTALL_WORKFLOW=false
+```
+
+(initialize near the other defaults at line 10-13), and:
+
+```bash
+        --workflow)
+            INSTALL_WORKFLOW=true
+            shift
+            ;;
+```
+
+- [ ] **Step 4: Gate the existing install block**
+
+Wrap the existing block at `scripts/setup.sh:489-502`:
+
+```bash
+if [ "$INSTALL_WORKFLOW" = true ] && [ -d "$STANDARDS_DIR/.github/actions/standards-review" ]; then
+    if [ ! -f "$PROJECT_ROOT/.github/workflows/standards-review.yml" ]; then
+        # ... existing body ...
+    fi
+elif [ -d "$STANDARDS_DIR/.github/actions/standards-review" ] && [ ! -f "$PROJECT_ROOT/.github/workflows/standards-review.yml" ]; then
+    echo "ℹ️  standards-review workflow available. To install: ./setup.sh --workflow"
+fi
+```
+
+(Copy the existing body verbatim into the `if INSTALL_WORKFLOW` branch.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `make test`
+Expected: 14/14 pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/setup.sh scripts/test-setup-safe.sh
+git commit -m "feat(setup): gate standards-review workflow install behind --workflow (1.2)"
+```
+
+---
+
+## Task 8: Emit `MERGE_PLAN.md` when pending files exist
+
+**Files:**
+- Create: `scripts/lib/merge-plan.sh`
+- Modify: `scripts/setup.sh` (call `write_merge_plan` after `setup_ai_agents` returns)
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```bash
+echo -n "Test 15: MERGE_PLAN.md is written when pending files exist... "
+proj=$(make_project "merge-plan")
+cat > "$proj/AGENTS.md" <<'EOF'
+# Existing AGENTS.md (customized)
+EOF
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents codex --languages typescript >/dev/null 2>&1) || true
+if [ -f "$proj/.standards-pending/MERGE_PLAN.md" ] \
+   && grep -q "AGENTS.md" "$proj/.standards-pending/MERGE_PLAN.md"; then
+    pass
+else
+    fail "MERGE_PLAN.md missing or does not list AGENTS.md"
+fi
+
+echo -n "Test 16: MERGE_PLAN.md NOT written when no pending files... "
+proj=$(make_project "no-merge-plan")
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents codex --languages typescript >/dev/null 2>&1) || true
+if [ ! -f "$proj/.standards-pending/MERGE_PLAN.md" ]; then pass; else fail "unexpected MERGE_PLAN.md"; fi
+```
+
+- [ ] **Step 2: Run tests — confirm 15 fails**
+
+Run: `make test-setup-safe`
+
+- [ ] **Step 3: Create `scripts/lib/merge-plan.sh`**
+
+```bash
+#!/bin/bash
+# Emit .standards-pending/MERGE_PLAN.md — the briefing that tells the user's
+# preferred LLM what to finish after setup.sh completes. Read by the
+# merge-standards skill (Claude Code), .cursor/commands/merge-standards.md
+# (Cursor), and surfaced via `make merge-standards`.
+
+# Usage:
+#   write_merge_plan <project_root> <pending_list> <detected_agents> <requested_agents>
+#
+# pending_list: space-separated basenames staged in .standards-pending/
+# detected_agents / requested_agents: space-separated agent names
+write_merge_plan() {
+    local root="$1"
+    local pending_list="$2"
+    local detected="$3"
+    local requested="$4"
+    local pending_dir="$root/.standards-pending"
+
+    [ -n "$pending_list" ] || return 0
+    mkdir -p "$pending_dir"
+
+    local plan="$pending_dir/MERGE_PLAN.md"
+    {
+        echo "# Standards Setup — Merge Plan"
+        echo ""
+        echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        echo ""
+        echo "setup.sh detected existing agent configs that differ from the assembled"
+        echo "versions. They have NOT been overwritten. Each pending file is staged here"
+        echo "alongside this plan."
+        echo ""
+        echo "## How to finish"
+        echo ""
+        echo "- **Claude Code:** run \`/merge-standards\`"
+        echo "- **Cursor:** run the \`merge-standards\` command"
+        echo "- **Any agent / manual:** \`make merge-standards\` or read the steps below"
+        echo ""
+        echo "## Pending files"
+        echo ""
+        for f in $pending_list; do
+            echo "- \`.standards-pending/$f\` → merge into \`$f\`"
+        done
+        echo ""
+        echo "## Detected agents"
+        echo ""
+        if [ -n "$detected" ]; then
+            for a in $detected; do echo "- $a"; done
+        else
+            echo "_(none detected — setup ran with explicit \`--agents\`)_"
+        fi
+        echo ""
+        echo "## Agents written this run"
+        echo ""
+        for a in $requested; do echo "- $a"; done
+        echo ""
+        echo "## Open questions for your LLM"
+        echo ""
+        echo "1. Fill in any \`<!-- TODO(standards): -->\` markers in the pending files"
+        echo "   (project overview, key commands)."
+        echo "2. For each pending file, decide: accept the assembled version, keep the"
+        echo "   existing, or merge section-by-section."
+        echo "3. After merging, delete the pending file and update \`.standards-checksums\`."
+        echo ""
+    } > "$plan"
+}
+```
+
+- [ ] **Step 4: Call the emitter from `setup.sh`**
+
+After the `setup_ai_agents "$STANDARDS_DIR" ...` call at `scripts/setup.sh:455`, and immediately before the "Set up git hooks" echo, add:
+
+```bash
+# Emit MERGE_PLAN.md if setup staged any pending updates.
+if [ -f "$SCRIPT_DIR/lib/merge-plan.sh" ] && [ -n "${PENDING_LIST:-}" ]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib/merge-plan.sh"
+    write_merge_plan "$PROJECT_ROOT" "$PENDING_LIST" "${DETECTED_AGENTS:-}" "${ASSEMBLED_AGENTS_LIST:-}"
+    echo ""
+    echo "📋 Pending updates staged. See .standards-pending/MERGE_PLAN.md or run:"
+    echo "   Claude Code: /merge-standards"
+    echo "   Cursor:      /merge-standards"
+    echo "   CLI:         make merge-standards"
+fi
+```
+
+**Note:** `PENDING_LIST` is a string accumulated inside `setup_ai_agents`. Make it globally accessible by removing `local` from its declaration in Task 4 (or exporting via a file). Simplest: change Task 4's `local PENDING_LIST=""` to just `PENDING_LIST=""` without `local`, so the outer scope can read it.
+
+Also, in Task 5's detection block, assign to an outer-scope `DETECTED_AGENTS` variable (not local) so MERGE_PLAN has access.
+
+- [ ] **Step 5: Run tests**
+
+Run: `make test`
+Expected: 16/16 pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/lib/merge-plan.sh scripts/setup.sh scripts/test-setup-safe.sh
+git commit -m "feat(setup): emit .standards-pending/MERGE_PLAN.md for preferred-LLM handoff (1.2)"
+```
+
+---
+
+## Task 9: Agent-agnostic merge entry points
+
+**Files:**
+- Modify: `standards/agents/claude-code/skills/merge-standards.md` (handle setup-time)
+- Create: `.cursor/commands/merge-standards.md`
+- Modify: `Makefile` (add `merge-standards` target)
+
+- [ ] **Step 1: Extend the Claude skill**
+
+Read `standards/agents/claude-code/skills/merge-standards.md`. Right after the "When to Use" section, add a new section:
+
+```markdown
+## Setup-time behavior
+
+When invoked immediately after `setup.sh`, `.standards-pending/MERGE_PLAN.md` exists and lists the files to reconcile. Read it first; it names each pending file, detected vs requested agents, and any `<!-- TODO(standards): -->` markers that need filling.
+
+For **empty targets** (the project had no existing config and `.standards-pending/` still contains the assembled version because `--agents detect` found it), the merge is a rename: move the pending file into place, update `.standards-checksums`, and delete the pending copy.
+
+For **`<!-- TODO(standards): -->` markers** in CLAUDE.md and friends: ask the user for a one-paragraph project overview and a list of key commands (or infer them from `package.json` scripts / Makefile targets) and replace the markers in place before completing the merge.
+```
+
+- [ ] **Step 2: Create the Cursor command**
+
+```markdown
+---
+description: Merge pending standards updates into agent configs
+---
+
+# merge-standards
+
+Read `.standards-pending/MERGE_PLAN.md` and walk through each pending file.
+
+For each entry:
+
+1. Read `.standards-pending/<file>` and the existing `<file>` at the project root.
+2. If the existing file is empty or missing, move the pending file into place.
+3. Otherwise produce a diff and ask the user: accept new, keep existing, or merge section-by-section.
+4. For any `<!-- TODO(standards): -->` markers, ask for the content (or infer from `package.json` / `Makefile`) and replace before writing.
+5. Update `.standards-checksums` with the new hash.
+6. Delete the pending file.
+
+Finally, delete `.standards-pending/` if empty.
+```
+
+Write to `.cursor/commands/merge-standards.md`.
+
+- [ ] **Step 3: Add `Makefile` target**
+
+After the `doctor:` target, add:
+
+```makefile
+merge-standards: ## Print the pending merge plan for manual / CLI review
+	@if [ -f .standards-pending/MERGE_PLAN.md ]; then \
+		cat .standards-pending/MERGE_PLAN.md; \
+	else \
+		echo "No pending standards updates. (.standards-pending/MERGE_PLAN.md not found)"; \
+	fi
+```
+
+Add `merge-standards` to the `.PHONY` line.
+
+- [ ] **Step 4: Test the target**
+
+Run: `make merge-standards`
+Expected: "No pending standards updates." (because none exist in the worktree).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add standards/agents/claude-code/skills/merge-standards.md \
+        .cursor/commands/merge-standards.md \
+        Makefile
+git commit -m "feat(skills): agent-agnostic /merge-standards entry points (1.2)"
+```
+
+---
+
+## Task 10: Changelog, blog post, CLAUDE.md update
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Create: `website/src/content/docs/blog/standards-1-2-safe-setup.md`
+- Modify: `CLAUDE.md` (mention the flow under "Conventions")
+
+- [ ] **Step 1: Update `CHANGELOG.md`**
+
+Replace the `## [Unreleased]` header with:
+
+```markdown
+## [Unreleased]
+
+## [1.2.0] - 2026-04-16
+
+### Changed — Safe setup (breaking for setup.sh defaults)
+
+- **`setup.sh` no longer clobbers existing agent configs.** Every assembly now routes through `should_assemble()`; customized files are staged as `.standards-pending/<file>` instead of overwritten. Applies to `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`, `AGENTS.md`, `.aider-instructions.md`.
+- **`--agents` defaults to `detect`** (was: install all six). Setup now probes for existing config files (`CLAUDE.md`, `.cursorrules`, etc.) and installs only for agents already in use. Escape hatches: `--agents all`, `--agents claude-code,cursor`, or explicit comma-separated list.
+- **`--workflow` gates the `standards-review.yml` install.** Previously copied unconditionally when missing; now opt-in. When skipped, setup prints the hint: `To install: ./setup.sh --workflow`.
+- **Template variables in `CLAUDE.md` are now resolved.** `{{PROJECT_NAME}}` is filled from `package.json` / `Cargo.toml` / `pyproject.toml` / directory name. `{{PROJECT_OVERVIEW}}` and `{{KEY_COMMANDS}}` are rewritten to `<!-- TODO(standards): -->` markers the merge skill fills in — never shipped as literal `{{...}}`.
+
+### Added
+
+- **`scripts/lib/assembly.sh`** — shared `assemble_agent_config_guarded()` used by both `setup.sh` and `sync-standards.sh`. First-run and re-sync now behave identically.
+- **`scripts/lib/detect-agents.sh`** — `detect_installed_agents()` probe used by `--agents detect`.
+- **`scripts/lib/template-vars.sh`** — `resolve_project_name`, `resolve_template_vars`.
+- **`scripts/lib/merge-plan.sh`** — `write_merge_plan()` emits `.standards-pending/MERGE_PLAN.md`.
+- **`.cursor/commands/merge-standards.md`** — Cursor-facing twin of the Claude Code skill.
+- **`make merge-standards`** — prints `MERGE_PLAN.md` for manual or agent-agnostic workflows.
+- **`scripts/test-setup-safe.sh`** — functional tests for pending-mode writes, agent detection, template-var resolution, workflow gate, MERGE_PLAN emission. Wired into `make test`.
+
+### Fixed
+
+- Re-running `setup.sh` on a project that already has customized `AGENTS.md` / `CLAUDE.md` no longer discards the user's work.
+- Assembled `CLAUDE.md` never ships with literal `{{PROJECT_NAME}}`, `{{PROJECT_OVERVIEW}}`, or `{{KEY_COMMANDS}}` tokens.
+```
+
+- [ ] **Step 2: Write the blog post**
+
+Create `website/src/content/docs/blog/standards-1-2-safe-setup.md`:
+
+```markdown
+---
+title: "Standards 1.2: Safe Setup"
+date: 2026-04-16
+authors:
+  - name: C65 LLC
+---
+
+The last release was about governance and drift. 1.2 is about a single promise we were quietly breaking: **`setup.sh` should never destroy the work you've already done in your repo.** A recent adoption surfaced four ways it could — an unresolved template clobbering `CLAUDE.md`, `AGENTS.md` overwritten on a second run, configs installed for agents the project doesn't use, a CI workflow appearing without anyone asking for it. This release closes all four, and in doing so ties the setup-time and sync-time flows together around a single idea: **stage, don't clobber.**
+
+## One rule, applied four ways
+
+Every file setup.sh wants to write now goes through the same gate that `sync-standards` has used for months: `should_assemble()`. If the target doesn't exist, write it. If it exists and matches the last-known assembled hash, overwrite it. If it exists and has been customized, write the new version to `.standards-pending/<file>` instead and carry on. Same function. Same `.standards-pending/` directory. Same merge skill on the other side. First-run and re-sync are now the same flow.
+
+That fix alone addresses the clobbered `AGENTS.md`. The other three rejections are variations on the same theme — defaults that assumed more than they should.
+
+## Agents you actually use
+
+`--agents` now defaults to `detect`. Setup probes for `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`, `AGENTS.md`, `.aiderrc` — and only installs configs for the agents it finds. A greenfield project gets a short message listing what's available and prompting for `--agents <list>` or `--agents all`. The "install everything, let the user delete what they don't need" default is gone.
+
+## Template vars that don't ship
+
+`standards/agents/claude-code/base-claude-code.md` has three placeholders: `{{PROJECT_NAME}}`, `{{PROJECT_OVERVIEW}}`, `{{KEY_COMMANDS}}`. Until 1.2, the assembler wrote them through as literal `{{...}}` tokens. Now: `{{PROJECT_NAME}}` resolves from `package.json` / `Cargo.toml` / `pyproject.toml` / directory name, and the two content placeholders become `<!-- TODO(standards): ... -->` markers. The merge skill fills them in. The shipped file never contains `{{`.
+
+## The workflow is opt-in
+
+The `standards-review.yml` workflow is powerful but opinionated — it can conflict with a project's existing CI. 1.2 gates its install behind `--workflow`. When skipped, setup prints the one-liner to install it later. No surprises.
+
+## The handoff: MERGE_PLAN.md
+
+When setup stages anything pending, it writes `.standards-pending/MERGE_PLAN.md`: the list of files to reconcile, detected vs requested agents, any unresolved markers, and the three commands that can finish the job — `/merge-standards` (Claude Code), the Cursor command of the same name, or plain `make merge-standards`. The idea is not that setup.sh finishes the install; it's that setup.sh hands a complete, agent-agnostic briefing to whichever LLM the user prefers, and *that* agent finishes the install against the user's actual preferences.
+
+## A note on scope
+
+This isn't a rewrite. The pending-mode infrastructure already existed — `sync-standards.sh` had been using it for months. The 1.2 change lifts that loop into `scripts/lib/assembly.sh` and points `setup.sh` at it. Most of the new code is in the lib (one file per concern: assembly, detection, template vars, merge plan), the tests that enforce each fix, and the docs that explain it. The four-rejection list that kicked this off maps, one-to-one, to four commits — and to four test groups that will keep them from regressing.
+```
+
+- [ ] **Step 3: Add a short note to `CLAUDE.md`**
+
+Under the existing `## Conventions` section in `CLAUDE.md`, append:
+
+```markdown
+- **Safe setup (1.2+)**: `setup.sh` never clobbers existing agent configs. Customized files are staged to `.standards-pending/` with a `MERGE_PLAN.md` describing how to reconcile them. The merge skill (`/merge-standards` in Claude Code / Cursor, `make merge-standards` via CLI) drives the agent-agnostic handoff.
+```
+
+- [ ] **Step 4: Run `make lint` to catch markdown issues**
+
+Run: `make lint` (if markdownlint is available; otherwise skip).
+Expected: no new errors. Fix any flagged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md website/src/content/docs/blog/standards-1-2-safe-setup.md CLAUDE.md
+git commit -m "docs(release): 1.2 changelog + safe-setup blog post"
+```
+
+---
+
+## Task 11: Final verification + PR
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `make test`
+Expected: all tests pass. Count: 10 (bootstrap) + 12 (gh-task) + 16 (setup-safe) = 38.
+
+- [ ] **Step 2: Dry-run setup against a real adopter project**
+
+Pick `/Users/donaldalbrecht/Projects/sagegrouse` (already has customized configs). Run:
+
+```bash
+cd /Users/donaldalbrecht/Projects/sagegrouse
+/Users/donaldalbrecht/Projects/coding-standards/.worktrees/1.2-safe-setup/scripts/setup.sh --dry-run
+```
+
+Expected: the output mentions pending staging for already-customized files, detected agents, and the MERGE_PLAN emission. No "Would overwrite" against customized configs.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/1.2-safe-setup
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat: Standards 1.2 safe setup" --body "$(cat <<'EOF'
+## Summary
+
+Standards 1.2 — `setup.sh` no longer clobbers customized configs, installs configs for agents the project doesn't use, ships literal `{{vars}}`, or silently drops in a competing CI workflow. All four concerns from the recent adoption feedback map one-to-one to a commit and a test group.
+
+Key changes:
+
+- Pending-mode writes via the same `should_assemble()` guard `sync-standards` already used. Lifted into `scripts/lib/assembly.sh` so setup and sync share one code path.
+- `--agents detect` is the new default. Greenfield projects get a prompt, not six unused configs.
+- `{{PROJECT_NAME}}` resolves from package metadata; `{{PROJECT_OVERVIEW}}` / `{{KEY_COMMANDS}}` become explicit TODO markers the merge skill fills in.
+- `--workflow` gates `standards-review.yml` install (was: unconditional when missing).
+- `.standards-pending/MERGE_PLAN.md` is the agent-agnostic handoff. `/merge-standards` (Claude / Cursor) and `make merge-standards` all read it.
+
+Blog post at `website/src/content/docs/blog/standards-1-2-safe-setup.md` explains the through-line.
+
+## Test plan
+
+- [x] `make test` — 38 tests pass (10 bootstrap + 12 gh-task + 16 setup-safe)
+- [ ] `./setup.sh --dry-run` in a real adopter project (e.g. sagegrouse) shows pending staging, no clobber
+- [ ] `./setup.sh --workflow` on the same project installs `standards-review.yml`
+- [ ] `/merge-standards` in Claude Code reads `MERGE_PLAN.md` and walks the user through reconciliation
+EOF
+)"
+```
+
+- [ ] **Step 5: Link the PR in the session summary for the user.**
+
+---
+
+## Self-review checklist (completed)
+
+- **Spec coverage:** All four rejections (clobbered `AGENTS.md`, `{{vars}}` in CLAUDE.md, unused-agent configs, competing workflow) have a dedicated task (4, 6, 5, 7). LLM-assist handoff covered by Tasks 8 + 9. Release artifacts (changelog, blog post, version identifier in CHANGELOG) covered by Task 10.
+- **Placeholder scan:** every step shows exact code or exact command; no "TBD" or "similar to".
+- **Type consistency:** `assemble_agent_config_guarded` signature and exit codes consistent between Task 2 (definition), Task 3 (sync caller), Task 4 (setup caller). `PENDING_LIST` and `DETECTED_AGENTS` scope notes in Task 8 preempt the classic bash "why is this empty" trap.

--- a/scripts/assemble-config.sh
+++ b/scripts/assemble-config.sh
@@ -2,7 +2,11 @@
 # Assemble a single self-contained agent config from a base template + content blocks.
 #
 # Usage:
-#   assemble-config.sh <agent> <blocks-dir> <base-template> <output-file> [block1 block2 ...]
+#   assemble-config.sh [--project-root <path>] <agent> <blocks-dir> <base-template> <output-file> [block1 block2 ...]
+#
+# Options:
+#   --project-root <path> — Explicit consumer project root for template-var resolution.
+#                           Falls back to git rev-parse on output-file's dir, then pwd.
 #
 # Arguments:
 #   agent         — Agent name (claude-code, cursor, copilot, gemini, aider, codex)
@@ -12,6 +16,23 @@
 #   block1...     — Additional block filenames (lang-python.md, role-service.md, etc.)
 
 set -e
+
+# ---------------------------------------------------------------------------
+# Option parsing (before positional args)
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT_OVERRIDE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --project-root)
+            PROJECT_ROOT_OVERRIDE="$2"
+            shift 2
+            ;;
+        --) shift; break ;;
+        -*) break ;;
+        *)  break ;;
+    esac
+done
 
 # ---------------------------------------------------------------------------
 # Argument validation
@@ -199,8 +220,13 @@ _TV_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/template-vars.sh"
 if [ -f "$_TV_LIB" ]; then
     # shellcheck disable=SC1090,SC1091
     source "$_TV_LIB"
-    # Assembler is sometimes invoked from inside a project; prefer that root.
-    _TV_ROOT="$(git -C "$(dirname "$OUTPUT_FILE")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+    # Prefer explicit override (passed by callers writing to temp files in pending/),
+    # then try git rev-parse on the output file's directory, then fall back to pwd.
+    if [ -n "$PROJECT_ROOT_OVERRIDE" ]; then
+        _TV_ROOT="$PROJECT_ROOT_OVERRIDE"
+    else
+        _TV_ROOT="$(git -C "$(dirname "$OUTPUT_FILE")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+    fi
     resolve_template_vars "$OUTPUT_FILE" "$_TV_ROOT"
 fi
 

--- a/scripts/assemble-config.sh
+++ b/scripts/assemble-config.sh
@@ -194,4 +194,14 @@ trap 'rm -f "$TMPFILE"' EXIT
 mv "$TMPFILE" "$OUTPUT_FILE"
 trap - EXIT
 
+# Resolve template variables ({{PROJECT_NAME}} etc.) in place.
+_TV_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/template-vars.sh"
+if [ -f "$_TV_LIB" ]; then
+    # shellcheck disable=SC1091
+    source "$_TV_LIB"
+    # Assembler is sometimes invoked from inside a project; prefer that root.
+    _TV_ROOT="$(git -C "$(dirname "$OUTPUT_FILE")" rev-parse --show-toplevel 2>/dev/null || pwd)"
+    resolve_template_vars "$OUTPUT_FILE" "$_TV_ROOT"
+fi
+
 echo "[$AGENT] Assembled config written to: $OUTPUT_FILE"

--- a/scripts/assemble-config.sh
+++ b/scripts/assemble-config.sh
@@ -197,7 +197,7 @@ trap - EXIT
 # Resolve template variables ({{PROJECT_NAME}} etc.) in place.
 _TV_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/template-vars.sh"
 if [ -f "$_TV_LIB" ]; then
-    # shellcheck disable=SC1091
+    # shellcheck disable=SC1090,SC1091
     source "$_TV_LIB"
     # Assembler is sometimes invoked from inside a project; prefer that root.
     _TV_ROOT="$(git -C "$(dirname "$OUTPUT_FILE")" rev-parse --show-toplevel 2>/dev/null || pwd)"

--- a/scripts/lib/assembly.sh
+++ b/scripts/lib/assembly.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Shared assembly loop used by setup.sh and sync-standards.sh.
+# Wraps scripts/assemble-config.sh with checksum guarding (should_assemble /
+# write_pending from lib/checksums.sh) so a customized target is staged as a
+# pending update instead of being clobbered.
+
+# Load checksum helpers if not already sourced.
+if ! type should_assemble >/dev/null 2>&1; then
+    _ASM_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck disable=SC1091
+    source "$_ASM_LIB_DIR/checksums.sh"
+fi
+
+# Usage:
+#   assemble_agent_config_guarded <agent> <assemble_script> <blocks_dir> \
+#       <base_template> <output_path> <checksums_path> <dry_run> [block ...]
+#
+# Exit codes:
+#   0 — wrote output (fresh or replacement)
+#   1 — wrote pending update (.standards-pending/)
+#   2 — skipped (manual file without assembly header; backup staged)
+#   3 — assembler failed
+#
+# On exit 0, caller should update its checksums using compute_hash +
+# update_checksum_entry. On exit 1, caller should track the basename in its
+# "pending" accumulator for MERGE_PLAN emission.
+assemble_agent_config_guarded() {
+    local agent="$1"
+    local assemble_script="$2"
+    local blocks_dir="$3"
+    local base_template="$4"
+    local output_path="$5"
+    local checksums_path="$6"
+    local dry_run="$7"
+    shift 7
+    local blocks=("$@")
+
+    if [ "$dry_run" = "true" ]; then
+        if [ -f "$output_path" ]; then
+            echo "  [dry-run] Would assemble (guarded): $output_path"
+        else
+            echo "  [dry-run] Would create: $output_path"
+        fi
+        return 0
+    fi
+
+    local sa_rc=0
+    should_assemble "$output_path" "$checksums_path" || sa_rc=$?
+
+    case "$sa_rc" in
+        0)
+            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+                "$output_path" ${blocks[@]+"${blocks[@]}"}; then
+                return 0
+            else
+                return 3
+            fi
+            ;;
+        1)
+            local tmp
+            tmp=$(mktemp)
+            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+                "$tmp" ${blocks[@]+"${blocks[@]}"} 2>/dev/null; then
+                write_pending "$output_path" "$agent"
+                cp "$tmp" "$PENDING_DIR/$(basename "$output_path")"
+                rm -f "$tmp"
+                return 1
+            else
+                rm -f "$tmp"
+                return 3
+            fi
+            ;;
+        2)
+            return 2
+            ;;
+    esac
+}

--- a/scripts/lib/assembly.sh
+++ b/scripts/lib/assembly.sh
@@ -71,6 +71,19 @@ assemble_agent_config_guarded() {
             fi
             ;;
         2)
+            # File exists with no assembly header and no stored hash — user-created file.
+            # should_assemble already wrote a .bak copy; now also assemble the new content
+            # into .standards-pending/ so the operator can review and merge.
+            local tmp
+            tmp=$(mktemp)
+            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+                "$tmp" ${blocks[@]+"${blocks[@]}"} 2>/dev/null; then
+                mkdir -p "$PENDING_DIR"
+                cp "$tmp" "$PENDING_DIR/$(basename "$output_path")"
+                rm -f "$tmp"
+            else
+                rm -f "$tmp"
+            fi
             return 2
             ;;
     esac

--- a/scripts/lib/assembly.sh
+++ b/scripts/lib/assembly.sh
@@ -47,9 +47,15 @@ assemble_agent_config_guarded() {
     local sa_rc=0
     should_assemble "$output_path" "$checksums_path" || sa_rc=$?
 
+    # Derive the pending directory relative to the consumer project root (not cwd).
+    local _project_root
+    _project_root="$(dirname "$checksums_path")"
+    local _pending_dir="$_project_root/$PENDING_DIR"
+
     case "$sa_rc" in
         0)
-            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+            if "$assemble_script" --project-root "$_project_root" \
+                "$agent" "$blocks_dir" "$base_template" \
                 "$output_path" ${blocks[@]+"${blocks[@]}"}; then
                 return 0
             else
@@ -59,10 +65,11 @@ assemble_agent_config_guarded() {
         1)
             local tmp
             tmp=$(mktemp)
-            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+            if "$assemble_script" --project-root "$_project_root" \
+                "$agent" "$blocks_dir" "$base_template" \
                 "$tmp" ${blocks[@]+"${blocks[@]}"} 2>/dev/null; then
-                write_pending "$output_path" "$agent"
-                cp "$tmp" "$PENDING_DIR/$(basename "$output_path")"
+                mkdir -p "$_pending_dir"
+                cp "$tmp" "$_pending_dir/$(basename "$output_path")"
                 rm -f "$tmp"
                 return 1
             else
@@ -76,15 +83,17 @@ assemble_agent_config_guarded() {
             # into .standards-pending/ so the operator can review and merge.
             local tmp
             tmp=$(mktemp)
-            if "$assemble_script" "$agent" "$blocks_dir" "$base_template" \
+            if "$assemble_script" --project-root "$_project_root" \
+                "$agent" "$blocks_dir" "$base_template" \
                 "$tmp" ${blocks[@]+"${blocks[@]}"} 2>/dev/null; then
-                mkdir -p "$PENDING_DIR"
-                cp "$tmp" "$PENDING_DIR/$(basename "$output_path")"
+                mkdir -p "$_pending_dir"
+                cp "$tmp" "$_pending_dir/$(basename "$output_path")"
                 rm -f "$tmp"
+                return 2
             else
                 rm -f "$tmp"
+                return 3
             fi
-            return 2
             ;;
     esac
 }

--- a/scripts/lib/detect-agents.sh
+++ b/scripts/lib/detect-agents.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Detect which AI agents are already in use in a project by probing for their
+# canonical config files. Called by setup.sh when --agents detect (default).
+# Output: space-separated agent names (claude-code, cursor, copilot, gemini,
+# codex, aider). Empty output = greenfield project.
+
+detect_installed_agents() {
+    local root="${1:-$(pwd)}"
+    local agents=()
+
+    [ -f "$root/CLAUDE.md" ]                         && agents+=("claude-code")
+    [ -f "$root/.cursorrules" ]                      && agents+=("cursor")
+    [ -d "$root/.cursor" ]                           && agents+=("cursor")
+    [ -f "$root/.github/copilot-instructions.md" ]   && agents+=("copilot")
+    [ -f "$root/.gemini/GEMINI.md" ]                 && agents+=("gemini")
+    [ -d "$root/.gemini" ]                           && agents+=("gemini")
+    [ -f "$root/AGENTS.md" ]                         && agents+=("codex")
+    [ -f "$root/.aiderrc" ]                          && agents+=("aider")
+    [ -f "$root/.aider-instructions.md" ]            && agents+=("aider")
+
+    printf '%s\n' "${agents[@]}" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+}

--- a/scripts/lib/merge-plan.sh
+++ b/scripts/lib/merge-plan.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Emit .standards-pending/MERGE_PLAN.md — the briefing that tells the user's
+# preferred LLM what to finish after setup.sh completes. Read by the
+# merge-standards skill (Claude Code), .cursor/commands/merge-standards.md
+# (Cursor), and surfaced via `make merge-standards`.
+
+# Usage:
+#   write_merge_plan <project_root> <pending_list> <detected_agents> <requested_agents>
+#
+# pending_list: space-separated basenames staged in .standards-pending/
+# detected_agents / requested_agents: space-separated agent names
+write_merge_plan() {
+    local root="$1"
+    local pending_list="$2"
+    local detected="$3"
+    local requested="$4"
+    local pending_dir="$root/.standards-pending"
+
+    [ -n "$pending_list" ] || return 0
+    mkdir -p "$pending_dir"
+
+    local plan="$pending_dir/MERGE_PLAN.md"
+    {
+        echo "# Standards Setup — Merge Plan"
+        echo ""
+        echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        echo ""
+        echo "setup.sh detected existing agent configs that differ from the assembled"
+        echo "versions. They have NOT been overwritten. Each pending file is staged here"
+        echo "alongside this plan."
+        echo ""
+        echo "## How to finish"
+        echo ""
+        echo "- **Claude Code:** run \`/merge-standards\`"
+        echo "- **Cursor:** run the \`merge-standards\` command"
+        echo "- **Any agent / manual:** \`make merge-standards\` or read the steps below"
+        echo ""
+        echo "## Pending files"
+        echo ""
+        for f in $pending_list; do
+            echo "- \`.standards-pending/$f\` → merge into \`$f\`"
+        done
+        echo ""
+        echo "## Detected agents"
+        echo ""
+        if [ -n "$detected" ]; then
+            for a in $detected; do echo "- $a"; done
+        else
+            echo "_(none detected — setup ran with explicit \`--agents\`)_"
+        fi
+        echo ""
+        echo "## Agents written this run"
+        echo ""
+        for a in $requested; do echo "- $a"; done
+        echo ""
+        echo "## Open questions for your LLM"
+        echo ""
+        echo "1. Fill in any \`<!-- TODO(standards): -->\` markers in the pending files"
+        echo "   (project overview, key commands)."
+        echo "2. For each pending file, decide: accept the assembled version, keep the"
+        echo "   existing, or merge section-by-section."
+        echo "3. After merging, delete the pending file and update \`.standards-checksums\`."
+        echo ""
+    } > "$plan"
+}

--- a/scripts/lib/merge-plan.sh
+++ b/scripts/lib/merge-plan.sh
@@ -8,7 +8,8 @@
 #   write_merge_plan <project_root> <pending_list> <detected_agents> <requested_agents>
 #
 # pending_list: space-separated basenames staged in .standards-pending/
-# detected_agents / requested_agents: space-separated agent names
+# detected_agents: space-separated agent names (as emitted by detect_installed_agents)
+# requested_agents: space- or comma-separated (ASSEMBLED_AGENTS_LIST uses commas)
 write_merge_plan() {
     local root="$1"
     local pending_list="$2"

--- a/scripts/lib/merge-plan.sh
+++ b/scripts/lib/merge-plan.sh
@@ -51,7 +51,7 @@ write_merge_plan() {
         echo ""
         echo "## Agents written this run"
         echo ""
-        for a in $requested; do echo "- $a"; done
+        for a in $(echo "$requested" | tr ',' ' '); do echo "- $a"; done
         echo ""
         echo "## Open questions for your LLM"
         echo ""

--- a/scripts/lib/template-vars.sh
+++ b/scripts/lib/template-vars.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Resolve {{PROJECT_NAME}}, {{PROJECT_OVERVIEW}}, {{KEY_COMMANDS}} in
+# assembled agent-config output. Called by assemble-config.sh right before the
+# output file is written.
+#
+# Philosophy: fill what we can from package metadata; replace what we can't
+# with explicit TODO markers so the user (or their LLM via /merge-standards)
+# can finish the job. Never leave literal {{...}} in shipped output.
+
+resolve_project_name() {
+    local root="${1:-$(pwd)}"
+    local name=""
+
+    if [ -f "$root/package.json" ]; then
+        name=$(grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' "$root/package.json" \
+               | head -1 \
+               | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+    fi
+    if [ -z "$name" ] && [ -f "$root/Cargo.toml" ]; then
+        name=$(grep -E '^name[[:space:]]*=' "$root/Cargo.toml" | head -1 \
+               | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/')
+    fi
+    if [ -z "$name" ] && [ -f "$root/pyproject.toml" ]; then
+        name=$(grep -E '^name[[:space:]]*=' "$root/pyproject.toml" | head -1 \
+               | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/')
+    fi
+    if [ -z "$name" ]; then
+        name=$(basename "$root")
+    fi
+    printf '%s' "$name"
+}
+
+# Usage: resolve_template_vars <file> <project_root>
+# Rewrites the file in place.
+resolve_template_vars() {
+    local file="$1"
+    local root="${2:-$(pwd)}"
+    [ -f "$file" ] || return 0
+
+    local project_name
+    project_name=$(resolve_project_name "$root")
+
+    # POSIX-safe in-place edit (macOS/BSD compatible)
+    local tmp
+    tmp=$(mktemp)
+    sed \
+        -e "s|{{PROJECT_NAME}}|${project_name}|g" \
+        -e "s|{{PROJECT_OVERVIEW}}|<!-- TODO(standards): one-paragraph project overview goes here. Run /merge-standards to fill. -->|g" \
+        -e "s|{{KEY_COMMANDS}}|<!-- TODO(standards): list key build/test/run commands. Run /merge-standards to fill. -->|g" \
+        "$file" > "$tmp" && mv "$tmp" "$file"
+}

--- a/scripts/lib/template-vars.sh
+++ b/scripts/lib/template-vars.sh
@@ -30,6 +30,12 @@ resolve_project_name() {
     printf '%s' "$name"
 }
 
+# Escape a string for safe use as a sed replacement value.
+# Handles \, &, and the | delimiter used in resolve_template_vars.
+_escape_sed_replacement() {
+    printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
 # Usage: resolve_template_vars <file> <project_root>
 # Rewrites the file in place.
 resolve_template_vars() {
@@ -39,12 +45,14 @@ resolve_template_vars() {
 
     local project_name
     project_name=$(resolve_project_name "$root")
+    local project_name_escaped
+    project_name_escaped=$(_escape_sed_replacement "$project_name")
 
     # POSIX-safe in-place edit (macOS/BSD compatible)
     local tmp
     tmp=$(mktemp)
     sed \
-        -e "s|{{PROJECT_NAME}}|${project_name}|g" \
+        -e "s|{{PROJECT_NAME}}|${project_name_escaped}|g" \
         -e "s|{{PROJECT_OVERVIEW}}|<!-- TODO(standards): one-paragraph project overview goes here. Run /merge-standards to fill. -->|g" \
         -e "s|{{KEY_COMMANDS}}|<!-- TODO(standards): list key build/test/run commands. Run /merge-standards to fill. -->|g" \
         "$file" > "$tmp" && mv "$tmp" "$file"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -203,7 +203,7 @@ setup_ai_agents() {
         fi
     fi
 
-    local ASSEMBLED_AGENTS_LIST=""
+    ASSEMBLED_AGENTS_LIST=""
     local NEW_CHECKSUMS=""
     PENDING_LIST=""
 
@@ -498,6 +498,18 @@ else
     echo ""
     echo "🤖 Setting up AI agent configurations..."
     setup_ai_agents "$STANDARDS_DIR" "$SCRIPT_DIR" "$PROJECT_ROOT"
+
+    # Emit MERGE_PLAN.md if setup staged any pending updates.
+    if [ -f "$SCRIPT_DIR/lib/merge-plan.sh" ] && [ -n "${PENDING_LIST:-}" ]; then
+        # shellcheck disable=SC1091
+        source "$SCRIPT_DIR/lib/merge-plan.sh"
+        write_merge_plan "$PROJECT_ROOT" "$PENDING_LIST" "${DETECTED_AGENTS:-}" "${ASSEMBLED_AGENTS_LIST:-}"
+        echo ""
+        echo "📋 Pending updates staged. See .standards-pending/MERGE_PLAN.md or run:"
+        echo "   Claude Code: /merge-standards"
+        echo "   Cursor:      /merge-standards"
+        echo "   CLI:         make merge-standards"
+    fi
 fi
 
 # Set up git hooks

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -83,6 +83,10 @@ if [ -f "$SCRIPT_DIR/lib/checksums.sh" ]; then
     # shellcheck disable=SC1091
     source "$SCRIPT_DIR/lib/checksums.sh"
 fi
+if [ -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib/assembly.sh"
+fi
 
 # Map detected languages to block filenames
 map_languages_to_blocks() {
@@ -181,6 +185,7 @@ setup_ai_agents() {
 
     local ASSEMBLED_AGENTS_LIST=""
     local NEW_CHECKSUMS=""
+    PENDING_LIST=""
 
     for agent in $AGENTS_LIST; do
         local BASE_TEMPLATE="$AGENTS_DIR/$agent/base-$agent.md"
@@ -206,25 +211,35 @@ setup_ai_agents() {
         esac
 
         echo "📝 Assembling $agent config..."
-        if [ "$DRY_RUN" = true ]; then
-            local TEMP_ASSEMBLED
-            TEMP_ASSEMBLED=$(mktemp)
-            if "$ASSEMBLE_SCRIPT" "$agent" "$BLOCKS_DIR" "$BASE_TEMPLATE" "$TEMP_ASSEMBLED" ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"} 2>/dev/null; then
-                echo "  [dry-run] Would write: $OUTPUT_PATH"
-            fi
-            rm -f "$TEMP_ASSEMBLED"
-            echo "✅ $agent config (dry-run)"
-        elif "$ASSEMBLE_SCRIPT" "$agent" "$BLOCKS_DIR" "$BASE_TEMPLATE" "$OUTPUT_PATH" ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"}; then
-            echo "✅ $agent config assembled"
-            if type compute_hash &>/dev/null; then
-                local new_hash
-                new_hash=$(compute_hash "$OUTPUT_PATH")
-                NEW_CHECKSUMS=$(update_checksum_entry "$(basename "$OUTPUT_PATH")" "$new_hash" "$NEW_CHECKSUMS")
-            fi
-        else
-            echo "⚠️  Failed to assemble $agent config (non-fatal, continuing...)"
-            continue
-        fi
+        local CHECKSUMS_PATH="$PROJECT_ROOT/$CHECKSUMS_FILE"
+        local rc=0
+        assemble_agent_config_guarded \
+            "$agent" "$ASSEMBLE_SCRIPT" "$BLOCKS_DIR" "$BASE_TEMPLATE" \
+            "$OUTPUT_PATH" "$CHECKSUMS_PATH" "$DRY_RUN" \
+            ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"} || rc=$?
+
+        case "$rc" in
+            0)
+                echo "✅ $agent config assembled"
+                if [ "$DRY_RUN" = false ] && type compute_hash &>/dev/null; then
+                    local new_hash
+                    new_hash=$(compute_hash "$OUTPUT_PATH")
+                    NEW_CHECKSUMS=$(update_checksum_entry "$(basename "$OUTPUT_PATH")" "$new_hash" "$NEW_CHECKSUMS")
+                fi
+                ;;
+            1)
+                echo "⚠️  $agent config already exists and differs — staged to $PENDING_DIR/"
+                PENDING_LIST="${PENDING_LIST:+$PENDING_LIST }$(basename "$OUTPUT_PATH")"
+                ;;
+            2)
+                echo "⚠️  $agent config was manually created — backup in $PENDING_DIR/"
+                PENDING_LIST="${PENDING_LIST:+$PENDING_LIST }$(basename "$OUTPUT_PATH")"
+                ;;
+            3)
+                echo "⚠️  Failed to assemble $agent config (non-fatal, continuing...)"
+                continue
+                ;;
+        esac
 
         # Aider special handling: also copy aiderrc.template to .aiderrc
         if [ "$agent" = "aider" ] && [ -f "$AGENTS_DIR/aider/aiderrc.template" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -177,10 +177,25 @@ setup_ai_agents() {
 
     # Determine which agents to set up
     local AGENTS_LIST
-    if [ -n "$AGENTS_OVERRIDE" ]; then
-        AGENTS_LIST=$(echo "$AGENTS_OVERRIDE" | tr ',' ' ')
+    if [ -n "$AGENTS_OVERRIDE" ] && [ "$AGENTS_OVERRIDE" != "detect" ]; then
+        if [ "$AGENTS_OVERRIDE" = "all" ]; then
+            AGENTS_LIST="claude-code cursor copilot gemini codex aider"
+        else
+            AGENTS_LIST=$(echo "$AGENTS_OVERRIDE" | tr ',' ' ')
+        fi
     else
-        AGENTS_LIST="claude-code cursor copilot gemini codex aider"
+        # Default: detect agents already in use in the project.
+        # Use the pre-detection snapshot captured before .cursor/commands was installed.
+        AGENTS_LIST="${PRE_DETECTED_AGENTS:-}"
+        DETECTED_AGENTS="$AGENTS_LIST"
+        if [ -z "$AGENTS_LIST" ]; then
+            echo "ℹ️  No agent configs detected. Pass --agents <list> or --agents all to install."
+            echo "   Detected agents: (none)"
+            echo "   Available: claude-code, cursor, copilot, gemini, codex, aider"
+            AGENTS_LIST=""
+        else
+            echo "ℹ️  Detected agents: $AGENTS_LIST"
+        fi
     fi
 
     local ASSEMBLED_AGENTS_LIST=""
@@ -440,6 +455,16 @@ else
     else
         echo "❌ Error: Could not find standards directory"
         exit 1
+    fi
+
+    # Detect agents early — before .cursor/commands install modifies the filesystem.
+    # This snapshot is used by setup_ai_agents() when --agents detect (default).
+    if [ -z "$AGENTS_OVERRIDE" ] || [ "$AGENTS_OVERRIDE" = "detect" ]; then
+        if [ -f "$SCRIPT_DIR/lib/detect-agents.sh" ]; then
+            # shellcheck disable=SC1091
+            source "$SCRIPT_DIR/lib/detect-agents.sh"
+            PRE_DETECTED_AGENTS=$(detect_installed_agents "$PROJECT_ROOT")
+        fi
     fi
 
     # Copy Cursor custom commands if they exist

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,6 +11,7 @@ ROLE="service"
 AGENTS_OVERRIDE=""
 LANGUAGES_OVERRIDE=""
 DRY_RUN=false
+INSTALL_WORKFLOW=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -28,6 +29,10 @@ while [ $# -gt 0 ]; do
             ;;
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        --workflow)
+            INSTALL_WORKFLOW=true
             shift
             ;;
         *)
@@ -527,7 +532,7 @@ HOOK
 fi
 
 # Install standards review workflow template
-if [ -d "$STANDARDS_DIR/.github/actions/standards-review" ]; then
+if [ "$INSTALL_WORKFLOW" = true ] && [ -d "$STANDARDS_DIR/.github/actions/standards-review" ]; then
     if [ ! -f "$PROJECT_ROOT/.github/workflows/standards-review.yml" ]; then
         if [ -f "$STANDARDS_DIR/templates/standards-review.yml.example" ]; then
             dry_run_mkdir "$PROJECT_ROOT/.github/workflows"
@@ -539,6 +544,8 @@ if [ -d "$STANDARDS_DIR/.github/actions/standards-review" ]; then
             fi
         fi
     fi
+elif [ -d "$STANDARDS_DIR/.github/actions/standards-review" ] && [ ! -f "$PROJECT_ROOT/.github/workflows/standards-review.yml" ]; then
+    echo "ℹ️  standards-review workflow available. To install: ./setup.sh --workflow"
 fi
 
 # Set up git aliases (global configuration)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -88,10 +88,12 @@ if [ -f "$SCRIPT_DIR/lib/checksums.sh" ]; then
     # shellcheck disable=SC1091
     source "$SCRIPT_DIR/lib/checksums.sh"
 fi
-if [ -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
-    # shellcheck disable=SC1091
-    source "$SCRIPT_DIR/lib/assembly.sh"
+if [ ! -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
+    echo "Error: required library 'assembly.sh' not found at $SCRIPT_DIR/lib/assembly.sh" >&2
+    exit 1
 fi
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/assembly.sh"
 
 # Map detected languages to block filenames
 map_languages_to_blocks() {

--- a/scripts/sync-standards.sh
+++ b/scripts/sync-standards.sh
@@ -75,6 +75,11 @@ if [ -n "$CHECKSUMS_LIB" ]; then
     source "$CHECKSUMS_LIB"
 fi
 
+if [ -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib/assembly.sh"
+fi
+
 # Map detected languages to block filenames (shared with setup.sh)
 map_languages_to_blocks() {
     local BLOCKS=()
@@ -209,51 +214,25 @@ sync_ai_agents() {
         esac
 
         # Checksum-guarded assembly: skip customized files, stage pending updates
-        if [ "$DRY_RUN" = true ]; then
-            if [ -f "$OUTPUT_PATH" ]; then
-                echo "  [dry-run] Would re-assemble: $OUTPUT_PATH"
-            else
-                echo "  [dry-run] Would create: $OUTPUT_PATH"
-            fi
-            continue
-        elif [ -n "$CHECKSUMS_LIB" ]; then
-            local sa_rc=0
-            should_assemble "$OUTPUT_PATH" "$CHECKSUMS_PATH" || sa_rc=$?
+        local rc=0
+        assemble_agent_config_guarded \
+            "$agent" "$ASSEMBLE_SCRIPT" "$BLOCKS_DIR" "$BASE_TEMPLATE" \
+            "$OUTPUT_PATH" "$CHECKSUMS_PATH" "$DRY_RUN" \
+            ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"} || rc=$?
 
-            if [ "$sa_rc" -eq 1 ]; then
-                # File has been customized — assemble to temp and stage as pending
-                local TEMP_ASSEMBLED
-                TEMP_ASSEMBLED=$(mktemp)
-                if "$ASSEMBLE_SCRIPT" "$agent" "$BLOCKS_DIR" "$BASE_TEMPLATE" "$TEMP_ASSEMBLED" ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"} 2>/dev/null; then
-                    write_pending "$OUTPUT_PATH" "$agent"
-                    cp "$TEMP_ASSEMBLED" "$PROJECT_ROOT/$PENDING_DIR/$(basename "$OUTPUT_PATH")"
-                fi
-                rm -f "$TEMP_ASSEMBLED"
-                echo "⚠️  $agent config customized — update staged to $PENDING_DIR/"
-            elif [ "$sa_rc" -eq 2 ]; then
-                # Manual file without assembly header — already backed up by should_assemble
-                echo "⚠️  $agent config was manually created — skipping, backup in $PENDING_DIR/"
-            else
-                # Safe to assemble
-                echo "📝 Re-assembling $agent config..."
-                if "$ASSEMBLE_SCRIPT" "$agent" "$BLOCKS_DIR" "$BASE_TEMPLATE" "$OUTPUT_PATH" ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"}; then
-                    echo "✅ $agent config synced"
+        case "$rc" in
+            0)
+                echo "✅ $agent config synced"
+                if [ "$DRY_RUN" = false ]; then
                     local new_hash
                     new_hash=$(compute_hash "$OUTPUT_PATH")
                     NEW_CHECKSUMS=$(update_checksum_entry "$(basename "$OUTPUT_PATH")" "$new_hash" "$NEW_CHECKSUMS")
-                else
-                    echo "⚠️  Failed to sync $agent config (non-fatal, continuing...)"
                 fi
-            fi
-        else
-            # Fallback: no checksum library available — assemble unconditionally
-            echo "📝 Re-assembling $agent config..."
-            if "$ASSEMBLE_SCRIPT" "$agent" "$BLOCKS_DIR" "$BASE_TEMPLATE" "$OUTPUT_PATH" ${BLOCK_ARGS[@]+"${BLOCK_ARGS[@]}"}; then
-                echo "✅ $agent config synced"
-            else
-                echo "⚠️  Failed to sync $agent config (non-fatal, continuing...)"
-            fi
-        fi
+                ;;
+            1) echo "⚠️  $agent config customized — update staged to $PENDING_DIR/" ;;
+            2) echo "⚠️  $agent config was manually created — skipping, backup in $PENDING_DIR/" ;;
+            3) echo "⚠️  Failed to sync $agent config (non-fatal, continuing...)" ;;
+        esac
 
         # Aider special handling: also sync aiderrc.template to .aiderrc
         if [ "$agent" = "aider" ] && [ -f "$AGENTS_DIR/aider/aiderrc.template" ]; then

--- a/scripts/sync-standards.sh
+++ b/scripts/sync-standards.sh
@@ -75,10 +75,12 @@ if [ -n "$CHECKSUMS_LIB" ]; then
     source "$CHECKSUMS_LIB"
 fi
 
-if [ -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
-    # shellcheck disable=SC1091
-    source "$SCRIPT_DIR/lib/assembly.sh"
+if [ ! -f "$SCRIPT_DIR/lib/assembly.sh" ]; then
+    echo "Error: required library 'assembly.sh' not found at $SCRIPT_DIR/lib/assembly.sh" >&2
+    exit 1
 fi
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/assembly.sh"
 
 # Map detected languages to block filenames (shared with setup.sh)
 map_languages_to_blocks() {

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -32,6 +32,13 @@ echo ""
 echo -n "Test 1: setup.sh exists and is executable... "
 if [ -x "$SETUP" ]; then pass; else fail "$SETUP not executable"; fi
 
+echo -n "Test 2: lib/assembly.sh exposes assemble_agent_config_guarded... "
+if bash -c "source '$REPO_ROOT/scripts/lib/assembly.sh' && type assemble_agent_config_guarded" >/dev/null 2>&1; then
+    pass
+else
+    fail "assemble_agent_config_guarded not defined after sourcing lib/assembly.sh"
+fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -53,6 +53,32 @@ else
     fail "sync-standards.sh does not source lib/assembly.sh"
 fi
 
+echo -n "Test 5: setup.sh preserves pre-existing AGENTS.md (no clobber)... "
+proj=$(make_project "preserve-agents")
+cat > "$proj/AGENTS.md" <<'EOF'
+# My Custom AGENTS.md
+This content must survive setup.sh.
+EOF
+# Stage a fake .standards/ checkout pointing at our repo so setup.sh can find templates.
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+ln -s "$REPO_ROOT/.gemini"   "$proj/.standards/.gemini" 2>/dev/null || true
+(cd "$proj" && "$SETUP" --agents codex --languages typescript >/dev/null 2>&1) || true
+if grep -q "must survive setup.sh" "$proj/AGENTS.md" 2>/dev/null; then
+    pass
+else
+    fail "AGENTS.md was clobbered by setup.sh"
+fi
+if [ -f "$proj/.standards-pending/AGENTS.md" ]; then
+    pass_pending=true
+else
+    pass_pending=false
+fi
+
+echo -n "Test 6: setup.sh stages pending AGENTS.md in .standards-pending/... "
+if [ "$pass_pending" = true ]; then pass; else fail "no pending AGENTS.md written"; fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -39,6 +39,20 @@ else
     fail "assemble_agent_config_guarded not defined after sourcing lib/assembly.sh"
 fi
 
+echo -n "Test 3: sync-standards still passes shellcheck/syntax after refactor... "
+if bash -n "$REPO_ROOT/scripts/sync-standards.sh" 2>/dev/null; then
+    pass
+else
+    fail "sync-standards.sh has syntax errors"
+fi
+
+echo -n "Test 4: sync-standards references assembly lib... "
+if grep -q "lib/assembly.sh" "$REPO_ROOT/scripts/sync-standards.sh"; then
+    pass
+else
+    fail "sync-standards.sh does not source lib/assembly.sh"
+fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Functional tests for Standards 1.2 safe-setup behavior.
+# Each test creates a temp project, runs setup.sh, and asserts outcomes.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETUP="$REPO_ROOT/scripts/setup.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+PASS=0; FAIL=0
+
+TMPDIR_BASE="$(mktemp -d "${TMPDIR:-/tmp}/test-setup-safe.XXXXXX")"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+pass() { echo -e "${GREEN}✓${NC}"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}✗${NC}"; echo "  Error: $1"; FAIL=$((FAIL + 1)); }
+
+make_project() {
+    local name="$1"
+    local dir="$TMPDIR_BASE/$name"
+    mkdir -p "$dir"
+    (cd "$dir" && git init -q && git commit -q --allow-empty -m "init")
+    echo "$dir"
+}
+
+echo -e "${BLUE}Testing Standards 1.2 safe-setup behavior${NC}"
+echo ""
+
+echo -n "Test 1: setup.sh exists and is executable... "
+if [ -x "$SETUP" ]; then pass; else fail "$SETUP not executable"; fi
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "${RED}$FAIL failures${NC}"
+    exit 1
+fi
+echo -e "${GREEN}All $PASS tests passed!${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -194,6 +194,43 @@ else
     fail "multi-agent list not rendered as separate bullets"
 fi
 
+echo -n "Test 18: {{PROJECT_NAME}} resolves safely for scoped npm name... "
+proj=$(make_project "scoped-name")
+cat > "$proj/package.json" <<'EOF'
+{ "name": "@acme/widget" }
+EOF
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/template-vars.sh' && resolve_project_name '$proj'")
+if [ "$result" = "@acme/widget" ]; then pass; else fail "got: $result"; fi
+
+echo -n "Test 19: template-vars handles & in project name without sed breakage... "
+proj=$(make_project "amp-name")
+# Simulate a dirname-fallback case by removing package.json and renaming dir
+mv "$proj" "$TMPDIR_BASE/a&b"
+proj="$TMPDIR_BASE/a&b"
+tmpfile=$(mktemp)
+printf '# {{PROJECT_NAME}} — Guide\n' > "$tmpfile"
+bash -c "source '$REPO_ROOT/scripts/lib/template-vars.sh' && resolve_template_vars '$tmpfile' '$proj'"
+if grep -q "^# a&b — Guide$" "$tmpfile"; then pass; else fail "got: $(cat "$tmpfile")"; fi
+rm -f "$tmpfile"
+
+echo -n "Test 20: template vars resolve from project root even when assembling to pending/... "
+proj=$(make_project "pending-vars")
+cat > "$proj/package.json" <<'EOF'
+{ "name": "pending-proj" }
+EOF
+cat > "$proj/CLAUDE.md" <<'EOF'
+# Existing CLAUDE.md
+EOF
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents claude-code --languages typescript >/dev/null 2>&1) || true
+if [ -f "$proj/.standards-pending/CLAUDE.md" ] && grep -q "^# pending-proj — Claude Code Guide$" "$proj/.standards-pending/CLAUDE.md" && ! grep -q "{{" "$proj/.standards-pending/CLAUDE.md"; then
+    pass
+else
+    fail "pending CLAUDE.md did not resolve {{PROJECT_NAME}} from consumer project"
+fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -131,6 +131,26 @@ else
     fail "CLAUDE.md contains literal {{...}} or was not written"
 fi
 
+echo -n "Test 13: setup.sh does NOT install standards-review.yml by default... "
+proj=$(make_project "no-workflow")
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+ln -s "$REPO_ROOT/.github"   "$proj/.standards/.github"
+ln -s "$REPO_ROOT/templates" "$proj/.standards/templates"
+(cd "$proj" && "$SETUP" --agents claude-code --languages typescript >/dev/null 2>&1) || true
+if [ ! -f "$proj/.github/workflows/standards-review.yml" ]; then pass; else fail "workflow installed without --workflow"; fi
+
+echo -n "Test 14: setup.sh --workflow DOES install standards-review.yml... "
+proj=$(make_project "with-workflow")
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+ln -s "$REPO_ROOT/.github"   "$proj/.standards/.github"
+ln -s "$REPO_ROOT/templates" "$proj/.standards/templates"
+(cd "$proj" && "$SETUP" --agents claude-code --languages typescript --workflow >/dev/null 2>&1) || true
+if [ -f "$proj/.github/workflows/standards-review.yml" ]; then pass; else fail "workflow not installed with --workflow"; fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -175,6 +175,25 @@ ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
 (cd "$proj" && "$SETUP" --agents codex --languages typescript >/dev/null 2>&1) || true
 if [ ! -f "$proj/.standards-pending/MERGE_PLAN.md" ]; then pass; else fail "unexpected MERGE_PLAN.md"; fi
 
+echo -n "Test 17: MERGE_PLAN.md renders comma-separated agents as separate bullets... "
+proj=$(make_project "multi-agent")
+cat > "$proj/AGENTS.md" <<'EOF'
+# Existing AGENTS.md (customized)
+EOF
+cat > "$proj/CLAUDE.md" <<'EOF'
+# Existing CLAUDE.md (customized)
+EOF
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents claude-code,codex --languages typescript >/dev/null 2>&1) || true
+plan="$proj/.standards-pending/MERGE_PLAN.md"
+if [ -f "$plan" ] && grep -q "^- claude-code$" "$plan" && grep -q "^- codex$" "$plan" && ! grep -q "claude-code,codex" "$plan"; then
+    pass
+else
+    fail "multi-agent list not rendered as separate bullets"
+fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -151,6 +151,30 @@ ln -s "$REPO_ROOT/templates" "$proj/.standards/templates"
 (cd "$proj" && "$SETUP" --agents claude-code --languages typescript --workflow >/dev/null 2>&1) || true
 if [ -f "$proj/.github/workflows/standards-review.yml" ]; then pass; else fail "workflow not installed with --workflow"; fi
 
+echo -n "Test 15: MERGE_PLAN.md is written when pending files exist... "
+proj=$(make_project "merge-plan")
+cat > "$proj/AGENTS.md" <<'EOF'
+# Existing AGENTS.md (customized)
+EOF
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents codex --languages typescript >/dev/null 2>&1) || true
+if [ -f "$proj/.standards-pending/MERGE_PLAN.md" ] \
+   && grep -q "AGENTS.md" "$proj/.standards-pending/MERGE_PLAN.md"; then
+    pass
+else
+    fail "MERGE_PLAN.md missing or does not list AGENTS.md"
+fi
+
+echo -n "Test 16: MERGE_PLAN.md NOT written when no pending files... "
+proj=$(make_project "no-merge-plan")
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents codex --languages typescript >/dev/null 2>&1) || true
+if [ ! -f "$proj/.standards-pending/MERGE_PLAN.md" ]; then pass; else fail "unexpected MERGE_PLAN.md"; fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -103,6 +103,34 @@ else
     fail "unused-agent configs installed (cursorrules or aiderrc present)"
 fi
 
+echo -n "Test 10: {{PROJECT_NAME}} resolves from package.json... "
+proj=$(make_project "vars-pkg-json")
+cat > "$proj/package.json" <<'EOF'
+{ "name": "acme-widget", "version": "1.0.0" }
+EOF
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/template-vars.sh' && resolve_project_name '$proj'")
+if [ "$result" = "acme-widget" ]; then pass; else fail "got: $result"; fi
+
+echo -n "Test 11: {{PROJECT_NAME}} falls back to directory name... "
+proj=$(make_project "fallback-dirname")
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/template-vars.sh' && resolve_project_name '$proj'")
+if [ "$result" = "fallback-dirname" ]; then pass; else fail "got: $result"; fi
+
+echo -n "Test 12: assembled CLAUDE.md has no literal {{vars}}... "
+proj=$(make_project "no-literal-vars")
+cat > "$proj/package.json" <<'EOF'
+{ "name": "testproj" }
+EOF
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents claude-code --languages typescript >/dev/null 2>&1) || true
+if [ -f "$proj/CLAUDE.md" ] && ! grep -q "{{" "$proj/CLAUDE.md"; then
+    pass
+else
+    fail "CLAUDE.md contains literal {{...}} or was not written"
+fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -79,6 +79,30 @@ fi
 echo -n "Test 6: setup.sh stages pending AGENTS.md in .standards-pending/... "
 if [ "$pass_pending" = true ]; then pass; else fail "no pending AGENTS.md written"; fi
 
+echo -n "Test 7: detect-agents returns claude-code when CLAUDE.md exists... "
+proj=$(make_project "detect-claude")
+touch "$proj/CLAUDE.md"
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/detect-agents.sh' && detect_installed_agents '$proj'")
+if echo "$result" | grep -qw "claude-code"; then pass; else fail "got: $result"; fi
+
+echo -n "Test 8: detect-agents returns empty for greenfield project... "
+proj=$(make_project "detect-empty")
+result=$(bash -c "source '$REPO_ROOT/scripts/lib/detect-agents.sh' && detect_installed_agents '$proj'")
+if [ -z "$(echo "$result" | tr -d '[:space:]')" ]; then pass; else fail "got: $result"; fi
+
+echo -n "Test 9: setup.sh --agents detect installs only detected agents... "
+proj=$(make_project "detect-only")
+touch "$proj/CLAUDE.md"
+mkdir -p "$proj/.standards"
+ln -s "$REPO_ROOT/standards" "$proj/.standards/standards"
+ln -s "$REPO_ROOT/scripts"   "$proj/.standards/scripts"
+(cd "$proj" && "$SETUP" --agents detect --languages typescript >/dev/null 2>&1) || true
+if [ ! -f "$proj/.cursorrules" ] && [ ! -f "$proj/.aiderrc" ]; then
+    pass
+else
+    fail "unused-agent configs installed (cursorrules or aiderrc present)"
+fi
+
 echo ""
 if [ "$FAIL" -gt 0 ]; then
     echo -e "${RED}$FAIL failures${NC}"

--- a/scripts/test-setup-safe.sh
+++ b/scripts/test-setup-safe.sh
@@ -20,7 +20,9 @@ make_project() {
     local name="$1"
     local dir="$TMPDIR_BASE/$name"
     mkdir -p "$dir"
-    (cd "$dir" && git init -q && git commit -q --allow-empty -m "init")
+    (cd "$dir" && git init -q \
+        && git -c user.email="test@test.local" -c user.name="Test" \
+               commit -q --allow-empty -m "init")
     echo "$dir"
 }
 

--- a/standards/agents/claude-code/skills/merge-standards.md
+++ b/standards/agents/claude-code/skills/merge-standards.md
@@ -11,6 +11,14 @@ Merge pending standards updates into agent configs that have been customized.
 
 Run this after `sync-standards` reports that agent configs have been customized and pending updates exist in `.standards-pending/`.
 
+## Setup-time behavior
+
+When invoked immediately after `setup.sh`, `.standards-pending/MERGE_PLAN.md` exists and lists the files to reconcile. Read it first; it names each pending file, detected vs requested agents, and any `<!-- TODO(standards): -->` markers that need filling.
+
+For **empty targets** (the project had no existing config and `.standards-pending/` still contains the assembled version because `--agents detect` found it), the merge is a rename: move the pending file into place, update `.standards-checksums`, and delete the pending copy.
+
+For **`<!-- TODO(standards): -->` markers** in CLAUDE.md and friends: ask the user for a one-paragraph project overview and a list of key commands (or infer them from `package.json` scripts / Makefile targets) and replace the markers in place before completing the merge.
+
 ## Workflow
 
 1. List files in `.standards-pending/`. If the directory is empty or doesn't exist, report: "All agent configs are up to date — no pending standards updates."

--- a/website/src/content/docs/blog/standards-1-2-safe-setup.md
+++ b/website/src/content/docs/blog/standards-1-2-safe-setup.md
@@ -1,0 +1,50 @@
+---
+title: "Standards 1.2: Safe Setup"
+date: 2026-04-16
+authors:
+  - name: C65 LLC
+---
+
+Last release was about governance and drift. This one is about a quieter promise we were breaking: **installing the standards into your project should never destroy the work you've already done there.**
+
+The feedback that kicked off 1.2 came from a real adoption. Someone ran `setup.sh` against a repo that already had an `AGENTS.md`, a `CLAUDE.md`, and a CI workflow. When the dust settled, their `AGENTS.md` had been overwritten, the new `CLAUDE.md` was full of literal `{{PROJECT_NAME}}` tokens, configs for five agents they don't use had been dropped into the root, and a `standards-review.yml` workflow had appeared without anyone asking for it. They cherry-picked out what they wanted and sent back a note: *here's what we rejected, and why.*
+
+Four problems. One underlying mistake — **defaults that assumed more than they should**. This release fixes all four and ties them together around a single idea: **stage, don't clobber.**
+
+## One rule, applied four ways
+
+`setup.sh` now routes every file it wants to write through the same gate that `sync-standards` has used for months: `should_assemble()`. If the target doesn't exist, write it. If it exists and still matches the last assembled hash, overwrite it. If it exists and has been customized, write the new version to `.standards-pending/<file>` instead and leave the original alone.
+
+The infrastructure for this wasn't new — we'd built it for re-syncs. What was new was pointing `setup.sh` at it. The assembly loop is now a single function in `scripts/lib/assembly.sh`, shared by both scripts. First-run and re-sync are the same flow. That one change closes the "clobbered AGENTS.md" complaint completely.
+
+## Only the agents you actually use
+
+`--agents` now defaults to `detect`. When you run `setup.sh`, it probes for `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`, `AGENTS.md`, `.aiderrc` — and only installs configs for the agents it finds. A greenfield project gets a short message listing what's available, not six unused dotfiles.
+
+The old "install everything, let the user delete what they don't need" default was well-intentioned but wrong. The escape hatch is still there — `--agents all` if you really do want everything, or `--agents claude-code,cursor` for an explicit list — but the default respects what's already in your tree.
+
+## Template variables that don't ship
+
+The base `CLAUDE.md` template has three placeholders: `{{PROJECT_NAME}}`, `{{PROJECT_OVERVIEW}}`, `{{KEY_COMMANDS}}`. Until this release, the assembler wrote them through as literal `{{...}}` tokens. If you weren't paying attention, your repo ended up with a `CLAUDE.md` that greeted the next agent with `# {{PROJECT_NAME}} — Claude Code Guide`.
+
+Now: `{{PROJECT_NAME}}` resolves from `package.json`, `Cargo.toml`, `pyproject.toml`, or the directory name — whichever comes first. The two content placeholders become `<!-- TODO(standards): -->` markers that the merge skill fills in. The shipped file never contains `{{`.
+
+## The workflow is opt-in
+
+The `standards-review.yml` workflow is useful, but it's also opinionated — it can conflict with a project's existing CI. 1.2 gates its install behind `--workflow`. When you skip it, setup prints the one-liner to install it later. No more workflow showing up unannounced.
+
+## The handoff: MERGE_PLAN.md
+
+Here's where it gets interesting. When `setup.sh` stages anything to `.standards-pending/`, it also writes a `MERGE_PLAN.md` alongside it — a short briefing that lists the files to reconcile, the agents detected in the project, any unresolved `<!-- TODO -->` markers, and three ways to finish the job:
+
+- `/merge-standards` in Claude Code
+- the `merge-standards` command in Cursor
+- `make merge-standards` at the CLI
+
+All three read the same MERGE_PLAN.md. The design goal is that `setup.sh` doesn't *finish* the install — it hands a complete, agent-agnostic briefing to whichever LLM the user prefers, and that agent finishes the install against the user's actual preferences. You pick the tool; we give it the context.
+
+## What this didn't require
+
+This release isn't a rewrite. The pending-mode infrastructure already existed — `sync-standards.sh` had been using it for months. The 1.2 change lifts that loop into `scripts/lib/assembly.sh` and points `setup.sh` at it. Most of the new code is in four small libs (one per concern: assembly, detection, template vars, merge plan), the 17 functional tests that enforce each fix, and the docs that explain it.
+
+Four rejections from one adoption. Four commits. Four test groups that will keep them from regressing. That's the whole release.


### PR DESCRIPTION
## Summary

Standards 1.2 — `setup.sh` no longer clobbers customized configs, installs configs for agents the project doesn't use, ships literal `{{vars}}`, or silently drops in a competing CI workflow. All four concerns from the recent adoption feedback map one-to-one to a commit and a test group.

Key changes:

- **Pending-mode writes** via the same `should_assemble()` guard `sync-standards` already used. Lifted into `scripts/lib/assembly.sh` so setup and sync share one code path.
- **`--agents detect` is the new default.** Greenfield projects get a prompt, not six unused configs. Escape hatches: `--agents all`, `--agents claude-code,cursor`.
- `{{PROJECT_NAME}}` resolves from package metadata; `{{PROJECT_OVERVIEW}}` / `{{KEY_COMMANDS}}` become explicit `<!-- TODO(standards): -->` markers the merge skill fills in.
- **`--workflow` gates `standards-review.yml` install** (was: unconditional when missing).
- **`.standards-pending/MERGE_PLAN.md`** is the agent-agnostic handoff. `/merge-standards` (Claude Code, Cursor) and `make merge-standards` all read it.

Blog post at `website/src/content/docs/blog/standards-1-2-safe-setup.md` explains the through-line.

## Test plan

- [x] `make test` — 49 tests pass (10 bootstrap + 12 gh-task + 10 format-results + 17 setup-safe)
- [x] `./setup.sh --dry-run` against sagegrouse (real adopter) shows detected agents, guarded-assembly path for every file, no workflow install without flag
- [ ] Merge, then re-run `setup.sh` on a real adopter project — confirm `.standards-pending/` populated with MERGE_PLAN.md, no files clobbered
- [ ] `/merge-standards` in Claude Code reads `MERGE_PLAN.md` and walks through reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)