### PR TITLE
docs(standards): monorepo, cross-platform & CI/CD standards from amicus lessons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`arch-06_monorepo_workspace_standards.md`** (new): multi-toolchain workspaces kept separate, per-member pipeline ownership ("own your scope, not your style"), running the build (not just typecheck), complete path/alias resolution across all resolvers, generated-artifact drift gates (clean-rebuild to reproduce), and workspace dependency hygiene.
+- **`arch-07_cross_platform_shared_core_standards.md`** (new): shared pure core + thin per-platform shells, conformance/golden-vector testing as the parity gate, FFI boundary coverage (export smoke / golden parity / edge cases), UI-changes-are-cross-platform-by-default scoping, and testing to the platform edges.
+- **`arch-08_ci_cd_pipeline_standards.md`** (new): local gate mirrors CI, consolidate the required gate + build once, don't-run-everything-per-PR (concurrency cancel, path filters, tiered heavy suites), caching (pinned actions, keyed/evicted caches), artifact retention, self-hosted runner caveats, and deploy channels & promotion.
+- `proc-03_code_review_expectations.md`: a **PR Definition of Done / merge loop** (full local gate → open → wait for automated review → address all feedback → all-green → squash-merge), automated/AI review treated as a first-class gate with an author self-review checklist of common findings, and a UI-PRs-need-sign-off case.
+- `proc-02_git_version_control_standards.md` § 5/§ 11: release-version vs build-version model, deploy channels & promotion, the scripted reviewable release cut, and a Stacked & Dependent PRs section (base-deletion trap, conflicting-PR-runs-no-checks, one `Closes #X` per line, `gh pr create` cwd inference).
+- `proc-04_agent_workflow_standards.md`: Worktree Hygiene (volatile root checkout, `gh pr create` cwd, frozen-lockfile install in fresh worktrees, hook repair) and UI sign-off / environment-specific visual baselines / cross-platform UI scope.
+- `arch-02_automation_standards.md`: `make hooks` target and stronger `make dev` provisioning (all toolchains + hooks, frozen-lockfile installs).
+- `arch-05_resilient_architecture_patterns.md` §§ 7–9: best-effort/isolated secondary subsystems, liveness & takeover for coordination singletons, and "don't swallow the root cause."
+- `core-standards.md`: an Untestable Boundaries policy under Testing Standards (no dead-branch coverage gaming; keep boundaries thin; flag manual verification) and references to the new `arch-06`/`arch-07`/`arch-08` standards.
+- Shared blocks updated to propagate into assembled agent configs: `git-workflow` (merge loop, small/stacked PRs, `gh pr create` cwd, stacked-PR retarget), `testing-policy` (untestable boundaries, run the build), `architecture-core` (best-effort secondary subsystems, preserve the cause).
 - `lang-04_swift_standards.md § 14`: Build & Project Generation (Apple platforms) — XcodeGen/Tuist as project source of truth, code-signing rules (set `DEVELOPMENT_TEAM`, never disable signing at `base`), CI override pattern, a diagnostic checklist for "code is unsigned" device-install failures, and a note (§14.5) on latent target-config gaps that surface when re-enabling signing (e.g. test targets requiring `GENERATE_INFOPLIST_FILE: YES`).
 
 ## [1.2.0] - 2026-04-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,8 @@ There are no build steps, no test suites, and no application to run. The primary
 ### Standards Documents (`standards/`)
 
 Markdown files organized by category with prefix-based naming:
-- `architecture/` (arch-01 through arch-03): Core architecture, automation standards, Cursor-specific automation
-- `languages/` (lang-01 through lang-11): Python, Java, Kotlin, Swift, Dart, TypeScript, JavaScript, Rust, Zig, Ruby, Ruby on Rails
+- `architecture/` (arch-01, arch-02, arch-04–arch-08): Core architecture, automation, data versioning/migration, resilient patterns, monorepo/workspace, cross-platform shared-core, CI/CD pipeline
+- `languages/` (lang-01 through lang-13): Python, Java, Kotlin, Swift, Dart, TypeScript, JavaScript, Rust, Zig, Ruby, Ruby on Rails, Go, Elixir
 - `process/` (proc-01 through proc-04): Documentation, git/version control, code review, agent workflow
 - `security/` (sec-01): Security guidelines with P0-P2 severity model
 - `shared/core-standards.md`: Canonical source of cross-cutting standards (Clean Architecture, SOLID, naming, testing coverage targets). All agent configs reference this file.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -17,7 +17,11 @@ This document explains the reorganized file hierarchy for easier navigation and 
 │   ├── architecture/              # Core architecture & automation standards
 │   │   ├── arch-01_project_standards_and_architecture.md
 │   │   ├── arch-02_automation_standards.md
-│   │   └── arch-03_cursor_automation_standards.md
+│   │   ├── arch-04_data_versioning_and_migration_standards.md
+│   │   ├── arch-05_resilient_architecture_patterns.md
+│   │   ├── arch-06_monorepo_workspace_standards.md
+│   │   ├── arch-07_cross_platform_shared_core_standards.md
+│   │   └── arch-08_ci_cd_pipeline_standards.md
 │   │
 │   ├── languages/                 # Language-specific standards
 │   │   ├── lang-01_python_standards.md
@@ -119,8 +123,8 @@ This document explains the reorganized file hierarchy for easier navigation and 
 
 | Category | Location | Files |
 |----------|----------|-------|
-| Architecture | `standards/architecture/` | arch-01 through arch-03 |
-| Languages | `standards/languages/` | lang-01 through lang-11 |
+| Architecture | `standards/architecture/` | arch-01, arch-02, arch-04 through arch-08 |
+| Languages | `standards/languages/` | lang-01 through lang-13 |
 | Process | `standards/process/` | proc-01 through proc-04 |
 | Security | `standards/security/` | sec-01 |
 

--- a/standards/README.md
+++ b/standards/README.md
@@ -6,8 +6,8 @@ This directory contains all coding standards documents organized by category.
 
 | Directory | Prefix | Contents |
 |-----------|--------|----------|
-| `architecture/` | `arch-XX` | Core architecture, automation, Cursor-specific |
-| `languages/` | `lang-XX` | Per-language standards (Python, Java, Kotlin, Swift, Dart, TypeScript, JavaScript, Rust, Zig, Ruby/Rails) |
+| `architecture/` | `arch-XX` | Core architecture, automation, data versioning/migration, resilient patterns, monorepo/workspace, cross-platform shared-core, CI/CD pipeline |
+| `languages/` | `lang-XX` | Per-language standards (Python, Java, Kotlin, Swift, Dart, TypeScript, JavaScript, Rust, Zig, Ruby/Rails, Go, Elixir) |
 | `process/` | `proc-XX` | Documentation, git workflow, code review, agent workflow |
 | `security/` | `sec-XX` | Security guidelines with P0-P2 severity model |
 | `shared/` | — | Cross-cutting standards (`core-standards.md`) referenced by all agent configs |

--- a/standards/architecture/arch-02_automation_standards.md
+++ b/standards/architecture/arch-02_automation_standards.md
@@ -21,8 +21,9 @@ Every project MUST include the following targets in the root `Makefile`:
 
 ### `make dev`
 * **Goal:** Setup stable local development environment.
-* **Requirement:** Must provision containers (Docker Compose) or strict virtual environments.
-* **Post-condition:** System is ready for coding immediately after execution.
+* **Requirement:** Must provision containers (Docker Compose) or strict virtual environments. On a multi-toolchain repo it MUST provision **every** toolchain a fresh machine needs (e.g. JS deps *and* the Rust toolchain) plus the git hooks — a contributor runs one command and is ready.
+* **Requirement:** Dependency installs use the lockfile (frozen/`ci`/`--locked` mode) so a fresh checkout or worktree reproduces the committed versions exactly.
+* **Post-condition:** System is ready for coding immediately after execution; pair with `make doctor` to verify every required tool is present.
 
 ### `make test`
 * **Goal:** Verify code integrity.
@@ -63,6 +64,11 @@ Every project MUST include the following targets in the root `Makefile`:
 ### `make repo-setup`
 * **Goal:** Initialize version control.
 * **Action:** Configures git hooks (pre-commit), submodules, and local git settings.
+
+### `make hooks`
+* **Goal:** (Re)install git hooks for the current checkout.
+* **Action:** Re-runs the hook installer (e.g. `pnpm exec lefthook install`, `pre-commit install`) so `.git/hooks/*` point at the current working tree.
+* **Why:** Hook installers can leave `.git/hooks/*` hardcoding a *deleted* worktree's path; switching between worktrees then breaks committing. `make hooks` repairs this. Declare the hook tool as a **root** dependency so it resolves at the repo root where `.git` lives, not only inside a sub-package.
 
 ### `make pr`
 * **Goal:** Create and populate a GitHub Pull Request from current branch to main.

--- a/standards/architecture/arch-05_resilient_architecture_patterns.md
+++ b/standards/architecture/arch-05_resilient_architecture_patterns.md
@@ -93,3 +93,52 @@ platform_paths module
 ## 6. Naming That Reinforces Architecture
 
 See [core-standards.md](../shared/core-standards.md) Section 2 for naming conventions.
+
+## 7. Secondary Subsystems Are Best-Effort and Isolated
+
+A **secondary** or **derived** subsystem (a mirror, an on-disk archive, a search
+index, a sync/replication path, telemetry) exists to reflect or augment the
+**primary** state. It must never be able to break the primary.
+
+### Rules
+
+* The primary write path is authoritative. Updating a secondary subsystem is
+  **best-effort**: wrap it so a failure is caught, logged (with a clear prefix,
+  e.g. `console.warn('[archive] …')`), and swallowed *at that boundary* — never
+  propagated into the primary operation.
+* Isolate each secondary side effect in its own `try`/`catch`. One mirror failing
+  must not void the result of a whole operation, nor abort the other side effects.
+* Keep the secondary subsystem behind a seam (a port/interface) so the primary
+  path depends on the abstraction, not the concrete mirror, and can run with it
+  disabled.
+* Make secondary work **opt-in / detect-only** where appropriate (run it only when
+  a change is detected) rather than forcing it on every operation.
+
+## 8. Coordination Singletons Need Liveness and Takeover
+
+When a single elected participant coordinates others — a leader tab holding a
+lock, a primary node, a lease holder — design for that singleton becoming
+**unresponsive**, not just for it dying cleanly.
+
+### Rules
+
+* Followers that depend on the singleton MUST have a bounded probe/timeout and a
+  recovery path (re-election, takeover, or a one-shot guarded reload). A
+  persistently unresponsive-but-alive leader otherwise wedges *every* dependent
+  indefinitely.
+* Liveness ≠ presence. A holder that still owns the lock but never answers is the
+  hard case — detect it via timeout and route to takeover, don't assume a held
+  lock means a healthy leader.
+* Test the "stale leader" path explicitly; it does not reproduce in a single-tab /
+  single-node dev setup, so it is easy to ship broken.
+
+## 9. Don't Swallow the Root Cause
+
+Degrading gracefully (§4) does **not** mean discarding the diagnostic.
+
+* When you catch-and-degrade at a boundary, **preserve and surface the original
+  cause** — log it, attach it to the wrapping error, expose it in a diagnostics
+  view. A generic "pipeline failed" with the real `cause` (e.g. `"probe timed
+  out"`) swallowed sends every future investigation down dead ends.
+* Wrapping errors to add context (§4) must chain the underlying error, not replace
+  it.

--- a/standards/architecture/arch-06_monorepo_workspace_standards.md
+++ b/standards/architecture/arch-06_monorepo_workspace_standards.md
@@ -1,0 +1,124 @@
+# Monorepo & Workspace Standards
+
+These standards apply to repositories that host multiple packages, apps, or
+toolchains in a single tree (pnpm/npm workspaces, Cargo workspaces, Gradle
+multi-project builds, Go modules, etc.). They complement the Clean Architecture
+layering in [core-standards.md](../shared/core-standards.md) — that describes how
+*layers* depend on each other; this describes how *workspace members* are built,
+checked, and kept from drifting apart.
+
+## 1. Workspace Layout
+
+* A single repository MAY contain multiple workspace members: shared libraries,
+  deployable apps, and tools. Group them by kind (`packages/`, `apps/`,
+  `crates/`, `tools/`) so the dependency direction is visible from the path.
+* Each member owns its manifest (`package.json`, `Cargo.toml`, `build.gradle`)
+  and its own build/test/lint pipeline. The root orchestrates members; it does
+  not reach inside them.
+* Shared business logic lives in inner members (libraries); deployable apps are
+  outer members that compose libraries. Apps MUST NOT import from one another —
+  extract the shared part into a library instead.
+
+## 2. Multiple Toolchains Are Kept Separate
+
+A repo may host more than one language toolchain (e.g. a JS/TS workspace built
+with pnpm + a task runner, and a Rust workspace built with cargo).
+
+* **Keep the toolchains deliberately separate.** Do not make one task runner
+  orchestrate another language's build. A JS task graph should not invoke
+  `cargo`, and vice versa — each has its own dependency graph, cache, and CI gate.
+* Provide one `make` entry point per toolchain gate (`make ci-js`, `make ci-rust`)
+  and a top-level `make ci` that runs both, so a contributor never has to know
+  which toolchain a change touched.
+* Document the split in `CONTRIBUTING.md`: which directories belong to which
+  toolchain, and which command gates each.
+
+## 3. Per-Member Pipeline Ownership
+
+* **Each member owns its scope, not its own style.** Shared style/config
+  (formatter options, lint rules, TS compiler options) lives in a single root
+  config that members inherit or *extend* — never fork. A member may extend the
+  root config to add a member-specific plugin (e.g. an Astro or Vue parser) but
+  MUST NOT override shared options, or the options silently drift between members.
+* A member MAY own its own *ignore* set (e.g. `.prettierignore`,
+  `.eslintignore`) because the generated/vendored paths it excludes are genuinely
+  member-specific. When adding one, copy the closest sibling's list rather than
+  inventing a new shape, so the only differences are the ones that member needs.
+* CI runs each member's own check over its own tree. A repo-wide check at the
+  root covers shared config and any member without its own gate. Together they
+  must leave no file unchecked.
+
+### Verify with the member's own gate
+
+A passing root-level or aggregated check is **not** sufficient evidence that a
+member is green. Before pushing a change to a member, run that member's full
+local gate (`make ci` from inside the member, or `<runner> --filter <member> ci`)
+— the member's gate is the authoritative one CI reproduces.
+
+## 4. Run the Build, Not Just the Typecheck
+
+In many workspaces the per-member `typecheck` (e.g. `tsc --noEmit`) and the CI
+`build` (e.g. `tsc -b` with project references) check **different file sets**.
+The build is usually the stricter of the two:
+
+* `typecheck` configs commonly **exclude test files**; the project-reference
+  build **includes** them.
+* Therefore a change that widens a shared interface can pass `typecheck` locally
+  yet fail CI `build`, because every test double / inline fake of that interface
+  now fails to compile.
+
+**Rules:**
+
+* When you widen or change a shared interface (a port, a trait, a public type),
+  grep the *whole* workspace for every implementer — including object-literal
+  fakes annotated `: TheInterface`, not just `class X implements Y` — and update
+  them all.
+* Run the member's `build` (or `make ci`), not just `typecheck`, before pushing.
+  Treat "typecheck + lint + test all pass" as insufficient until the build is green.
+
+## 5. Path & Alias Resolution Must Be Complete
+
+When a member maps a package to a path alias (in `tsconfig`, a bundler config, a
+test-runner config, etc.), a **bare-package alias shadows unlisted subpaths**.
+Mapping `@scope/pkg` does not automatically map `@scope/pkg/sub` — the subpath
+silently resolves somewhere else (or fails only in one tool).
+
+**Rules:**
+
+* List **every** subpath alias a member imports, in **every** resolver that
+  member uses (the bundler config, the test-runner config, and the typechecker
+  config must agree). A subpath that resolves in the bundler but not the
+  typechecker is a latent break.
+* When you add a new subpath import, add its alias to all resolvers in the same
+  change. When copying a member's alias map to a new member, copy it whole.
+* Prefer the package manager's native workspace resolution over hand-maintained
+  alias maps where possible; reserve aliases for cases the resolver can't cover.
+
+## 6. Generated & Committed Artifacts
+
+Some workspaces commit build outputs that are derived from source (e.g.
+WASM/`.d.ts` bundles, generated clients, protobuf stubs) and gate CI on
+"the committed artifact matches a fresh rebuild" (`git diff --exit-code` after
+regenerating).
+
+* These artifacts MUST be regenerated and committed whenever their source — or a
+  **dependency that affects codegen output** — changes. A dependency bump can
+  change generated bytes even with no source edit.
+* **An incremental rebuild over a warm cache can reproduce stale output** and
+  show no drift locally, then fail the CI gate. Reproduce the gate with a *clean*
+  build (`cargo clean`, clear the codegen cache) before trusting a "no drift"
+  result.
+* Pin the codegen toolchain (compiler version, codegen plugin version) so the
+  output is deterministic across machines and matches the CI runner.
+
+## 7. Workspace Dependency Hygiene
+
+* No circular dependencies between members. Enforce with a tool
+  (`madge`, `cargo-deny`/`cargo tree`, `dependency-cruiser`) in CI.
+* Align shared dependency versions across members — a single version of each
+  third-party library per workspace, hoisted where the package manager supports
+  it. Divergent versions cause duplicate bundles and subtle behavior differences.
+* Commit a single lock file per toolchain at the workspace root. Install from the
+  lock in CI and in fresh worktrees (see
+  [proc-04_agent_workflow_standards.md](../process/proc-04_agent_workflow_standards.md)
+  § Worktree Hygiene).

--- a/standards/architecture/arch-07_cross_platform_shared_core_standards.md
+++ b/standards/architecture/arch-07_cross_platform_shared_core_standards.md
@@ -1,0 +1,97 @@
+# Cross-Platform Shared-Core Standards
+
+These standards apply to products that ship the same experience across multiple
+platforms (web, native desktop, mobile) from one codebase. They build on the
+"pure render logic" pattern in
+[arch-05_resilient_architecture_patterns.md](./arch-05_resilient_architecture_patterns.md)
+§2 and the workspace rules in
+[arch-06_monorepo_workspace_standards.md](./arch-06_monorepo_workspace_standards.md).
+
+The governing principle: **logic is shared and written once; rendering is
+per-platform.** A behavior difference between platforms is a bug, not a platform
+characteristic.
+
+## 1. Shared Core, Per-Platform Shells
+
+* Put all platform-agnostic logic — domain rules, data model, parsing,
+  serialization, reconciliation, business calculations — in a **single shared
+  core** (e.g. a Rust crate compiled to WASM for web and exposed via FFI for
+  native; a TS package consumed by every web app). The core has no UI and no
+  platform imports.
+* Each platform has a **thin shell** that renders the core's output using native
+  primitives (SwiftUI on Apple, Compose on Android, the DOM on web). Shells
+  contain rendering and platform glue only — no business logic.
+* **Prefer a native shell over wrapping a web view** when platform-native feel is
+  a product goal. A web view embedded in a native app is acceptable as an interim
+  step (document it as such in an ADR), but the target is a native rendering of
+  the shared core.
+
+### Single source of truth for shared data/logic
+
+Data and logic consumed by more than one shell live in the core, exposed through
+one API that every shell calls. Do not reimplement a rule (a permission check, a
+mapping, an ordering) in each shell — when it changes, the shells silently
+diverge. Example: a "which app owns this folder" mapping belongs in the shared
+core and is consumed identically by the web component and the native component.
+
+## 2. Conformance / Golden-Vector Testing Is the Parity Gate
+
+A shared core is only trustworthy if every binding produces identical results.
+Enforce this with **conformance testing**: a single, language-neutral set of
+input→expected-output vectors that every platform binding runs.
+
+* Maintain the vectors as data (JSON/CSV/binary fixtures) in one place, with a
+  documented schema. Each binding (the Rust unit tests, the WASM harness, the
+  Swift FFI tests, the Android JNI tests) loads the *same* vectors and asserts
+  the same outputs.
+* A change to core behavior updates the vectors once; every binding's conformance
+  test then re-verifies against the new expectation. Diverging output on any
+  platform fails CI.
+* Golden vectors are especially important for serialization round-trips, text
+  diffing/merging, and any algorithm where a one-byte difference across platforms
+  corrupts data.
+
+## 3. FFI Boundary Coverage
+
+When the core crosses a foreign-function boundary (WASM, UniFFI, JNI, C ABI),
+the boundary itself is a tested surface, not an afterthought.
+
+* **Export smoke tests:** assert every exported symbol is reachable from the host
+  language and round-trips a basic value. A binding that fails to generate or
+  link is caught here, not at runtime on a device.
+* **Golden parity at the boundary:** run the conformance vectors *through* the FFI
+  layer, not just against the core directly — serialization across the boundary is
+  where encoding/endianness/null-handling bugs live.
+* **Boundary/edge cases:** empty inputs, maximum sizes, all-optional-fields-absent,
+  invalid UTF-8, and other adversarial inputs that exercise the marshaling code.
+* Pin the binding generator version (e.g. `wasm-pack`, `uniffi-bindgen`) and treat
+  the generated bindings as committed generated artifacts (see
+  [arch-06](./arch-06_monorepo_workspace_standards.md) §6).
+
+## 4. UI Changes Are Cross-Platform by Default
+
+When a product ships the same UX on multiple platforms, a UI change is assumed to
+apply to **every** platform unless explicitly scoped otherwise.
+
+* Scope UI issues and PRs to cover **all** surfaces — web *and* each native shell —
+  with an acceptance criterion per surface. A web-only change silently leaves the
+  native shells behind.
+* Keep the shared data/logic behind the change single-sourced in the core (§1);
+  only the rendering is implemented per shell.
+* If a change genuinely applies to one platform only, say so in the issue/PR and
+  give the reason (a platform-specific affordance, a capability gap). Silence
+  defaults to "all platforms."
+
+## 5. Testing Reaches the Platform Edges
+
+* Logic is tested in the core with the conformance suite (platform-independent,
+  runs in CI everywhere).
+* Each shell has a thin layer of platform tests for rendering and glue.
+* Runtime surfaces that **cannot** run in CI (a real filesystem-access API, a
+  device keychain, a native window server) are handled per the untestable-boundary
+  policy in [core-standards.md](../shared/core-standards.md) (Testing Standards):
+  keep the boundary thin, push logic into the pure core where the conformance
+  suite covers it, and flag the residual manual-verification step explicitly.
+* See [arch-05](./arch-05_resilient_architecture_patterns.md) §3 for choosing
+  layout by **semantic state** (a `LayoutMode` computed from dimensions) rather
+  than platform detection — the same semantic state drives every shell.

--- a/standards/architecture/arch-08_ci_cd_pipeline_standards.md
+++ b/standards/architecture/arch-08_ci_cd_pipeline_standards.md
@@ -1,0 +1,102 @@
+# CI/CD Pipeline Standards
+
+These standards govern how continuous-integration pipelines are structured so they
+stay **fast, cheap, and trustworthy** as a repository grows. They assume the
+`make`-based automation in
+[arch-02_automation_standards.md](./arch-02_automation_standards.md) and the
+workspace model in
+[arch-06_monorepo_workspace_standards.md](./arch-06_monorepo_workspace_standards.md).
+
+CI minutes cost real money, and per-job setup overhead is itself a cost. Treat the
+pipeline as something to be measured and optimized, not left to sprawl.
+
+## 1. Local Gate Mirrors CI Exactly
+
+* The local gate (`make ci`) MUST run the same checks as the required CI gate —
+  same linters, same coverage thresholds, same build. "Green locally, red in CI"
+  (or the reverse) means the gate has drifted; fix the drift, don't paper over it.
+* CI SHOULD invoke the same `make` targets a developer runs, so there is one
+  definition of "passing" and no CI-only logic to keep in sync.
+
+## 2. Consolidate the Required Gate; Build Once
+
+* Prefer **one consolidated required gate** over a sprawl of overlapping per-member
+  workflows that each cold-install dependencies and rebuild shared packages. A
+  task runner with a dependency graph (turbo, nx, bazel, gradle) runs each unit of
+  work once across the workspace.
+* **Build each artifact exactly once per run.** Two jobs building the same output
+  in parallel waste minutes and can race on a shared output directory. Produce the
+  build once and let dependent jobs consume it.
+* Keep the **required** gate minimal and fast. Move advisory checks (dependency
+  CVE audit, license scan, link-checking) into **separate** jobs that do not block
+  merge — a transitive advisory should not wedge the required gate.
+
+## 3. Don't Run Everything on Every PR
+
+* **Cancel superseded runs.** Set a concurrency group keyed on
+  workflow + ref with cancel-in-progress, so a new push cancels the previous run
+  instead of paying for both.
+* **Path filters / affected-only.** Only run a member's gate when files in its
+  dependency closure changed. Document each member's filter (and why it is what it
+  is) next to the filter.
+* **Tier the heavy suites.** Expensive matrices — full cross-browser E2E,
+  visual-regression across themes, multi-OS builds — run on a reduced set per PR
+  (e.g. one browser) and the **full** matrix on a nightly schedule plus manual
+  dispatch. State the reduction explicitly; never let "we only test one browser on
+  PRs" be a silent gap.
+
+## 4. Caching
+
+* Cache the expensive, deterministic inputs: dependency stores, compiled
+  artifacts, browser binaries, task-runner outputs.
+* **Pin cache-action and tool versions to an exact version** — never a floating
+  major tag — so a cache key or action upgrade can't silently change behavior
+  mid-stream.
+* Key caches precisely (OS + tool version + lockfile hash + browser set). Use
+  `restore-keys` to fall back from a narrow set to a superset, never the reverse.
+* Give remote/task caches a **bounded budget with eviction** (LRU to a size cap on
+  a schedule). An unbounded cache grows until it costs more than it saves.
+* On a **persistent self-hosted runner**, prefer the runner's local on-disk store
+  over re-downloading a cache tarball every job — the redundant fetch can dominate
+  setup time.
+
+## 5. Artifacts & Retention
+
+* Set an explicit short retention on build/test artifacts (screenshots, logs,
+  coverage reports) — they accumulate storage cost. A week is a reasonable default
+  unless a longer window is needed for a specific audit.
+* Upload diagnostic artifacts (failing screenshots, logs) on failure so a red run
+  is debuggable without re-running.
+
+## 6. Self-Hosted Runners
+
+Self-hosted runners trade per-minute cost for operational responsibility. If used:
+
+* A job pinned to a self-hosted label **queues indefinitely if no matching runner
+  is online** — there is no hosted fallback. A check stuck "queued/pending" on a
+  self-hosted job means the runner is down, not that the code is slow. Document the
+  runner's labels and who owns it.
+* `runs-on` labels must match the runner's actual auto-labels (a macOS runner has
+  no `linux` label). A mismatch means the job never schedules.
+* Pin the toolchain the runner self-provisions (e.g. via a `rust-toolchain.toml`,
+  `.nvmrc`, `.tool-versions`) so a fresh runner reproduces the gate deterministically.
+* **Avoid shared mutable state between concurrent runners on one host.** Two
+  runners self-installing into the same shared tool directory will race and corrupt
+  it (e.g. `ENOTEMPTY` during a parallel dependency-manager install). Give each
+  runner its own home/work directory, or reduce concurrency, or move the
+  self-install into per-runner scope.
+
+## 7. Deploy Channels & Promotion
+
+For products that deploy from CI, separate **staging** from **production** by
+channel and gate promotion explicitly:
+
+* Pushes to the integration branch deploy to a **staging/preview** channel; production
+  deploys are gated on an explicit promotion (a long-lived `release` branch, a tag,
+  or a manual approval). **Never deploy production off arbitrary feature branches.**
+* If the platform's branch controls take no wildcard, use a single long-lived
+  promotion branch (`release`), not a pattern (`release/*`), and promote by
+  fast-forwarding into it.
+* See [proc-02_git_version_control_standards.md](../process/proc-02_git_version_control_standards.md)
+  §5 for the release-version vs build-version model and the scripted release PR
+  that drives promotion.

--- a/standards/process/proc-02_git_version_control_standards.md
+++ b/standards/process/proc-02_git_version_control_standards.md
@@ -158,6 +158,50 @@ Format: `MAJOR.MINOR.PATCH` (e.g., `1.2.3`)
 6. Create GitHub/GitLab release with notes
 7. Merge back to `develop` if applicable
 
+### Release Version vs. Build Version
+
+For products that deploy continuously, distinguish two version numbers:
+
+* **Release version** — manual semantic version (`MAJOR.MINOR.PATCH`), bumped
+  deliberately at a release. It is what users see and what gates a coordinated
+  release (e.g. apps and marketing site move together on a release-version bump).
+* **Build version** — derived automatically and ticking on every commit to the
+  mainline (e.g. `git rev-list --count HEAD`). Useful for "exact build" reporting
+  and crash triage, never for user-facing semver decisions.
+
+Surface both in an About/diagnostics view. A value only tree-shakes in if it is
+actually *rendered* — exporting it isn't enough.
+
+### Deploy Channels & Promotion
+
+* Separate **staging/preview** from **production** by channel. The mainline
+  branch auto-deploys to the staging channel; production is gated on an explicit
+  promotion. **Never deploy production off arbitrary feature branches.**
+* If the deploy platform's branch control takes no wildcard, gate production on a
+  single long-lived `release` branch (not `release/*`) and promote by
+  fast-forwarding mainline into it (`git push origin main:release`).
+* Channel-gate not-yet-released content (e.g. an "unreleased" changelog section
+  visible only on the staging channel) via a build-time channel variable. Verify
+  the variable name matches what the deploy platform actually injects — a typo
+  (`PUBLIC_CHANNEL` vs `VITE_CHANNEL`) silently ships the wrong content.
+
+### Scripted, Reviewable Release Cut
+
+Automate the release cut as a **script that produces a reviewable PR**, not a
+manual sequence of edits:
+
+* A pure script performs the semver bump and promotes changelog entries
+  (`unreleased/` → the released version section), and emits the release-notes body.
+* The script opens (or prepares) a PR for human review before anything is tagged
+  or promoted. Tagging and channel promotion happen only after that PR merges.
+* Mind CI-identity loop-prevention: a PR opened by a CI token often does **not**
+  trigger the normal PR gate, so a fully hands-free release usually needs a
+  dedicated app token or a human to open/merge the cut PR. Document which model
+  the repo uses.
+
+See [arch-08_ci_cd_pipeline_standards.md](../architecture/arch-08_ci_cd_pipeline_standards.md)
+§7 for the CI side of channel promotion.
+
 ## 6. Git Configuration
 
 ### Required Settings
@@ -390,3 +434,45 @@ As a guideline, a repository should have fewer than **10 active branches** at an
 * **Remote Repository:** Always push to remote (GitHub, GitLab, etc.)
 * **Multiple Remotes:** Consider backup remote for critical projects
 * **Regular Pushes:** Push at least daily during active development
+
+## 11. Stacked & Dependent PRs and Platform Automation Traps
+
+When PRs depend on each other or are driven by automation, a handful of
+platform behaviors silently cause lost work or false signals. Encode them.
+
+### Stacked PRs — the base-deletion trap
+
+When PR **B** is based on PR **A**'s branch (B's base = A's feature branch):
+
+* Merging **A** with delete-branch (`gh pr merge A --squash --delete-branch`)
+  **closes B** — the host does *not* auto-retarget B to mainline, and B cannot be
+  reopened once its base branch is gone.
+* **Avoid it:** before merging A, either retarget B to mainline first
+  (`gh pr edit B --base main`) while A's branch still exists, or merge A *without*
+  deleting its branch until B is retargeted.
+* **Recover** (if B was already closed by an A merge): in B's worktree,
+  `git rebase --onto origin/main <A-tip-commit>` to drop A's now-redundant commits
+  (their content is in mainline via the squash) and replay only B's own commits,
+  then open a fresh PR B′ → mainline referencing the closed one.
+
+### A conflicting PR runs no checks
+
+A PR with merge conflicts has no merge ref, so the host runs **none** of its
+merge-ref-triggered workflows — it looks like CI never fired (zero runs created,
+not even queued). If a PR's checks are entirely absent, check its mergeable state
+and resolve the conflict; the checks then trigger normally. Distinguish this from
+a self-hosted runner being offline (which produces a *queued* run that waits).
+
+### Other host-automation traps
+
+* **One close-keyword per line.** `Closes #A, #B, #C` only auto-closes the *first*
+  issue. Write one `Closes #X` per line to fan out across issues.
+* **Check polling can settle early.** Right after a push, only fast external checks
+  are registered; host-run jobs appear seconds later. A poll that exits as soon as
+  "all known checks are non-pending" can exit before real CI starts — guard with a
+  minimum-expected-check count.
+* **`gh pr create` infers the branch from the current directory.** Run it from the
+  correct worktree, or pass `--head <branch>` explicitly, or it opens a PR for
+  whatever branch the cwd is on. See
+  [proc-04_agent_workflow_standards.md](./proc-04_agent_workflow_standards.md)
+  § Worktree Hygiene.

--- a/standards/process/proc-03_code_review_expectations.md
+++ b/standards/process/proc-03_code_review_expectations.md
@@ -9,6 +9,33 @@
 * **Status:** Request review when code is complete, tested, and ready for feedback
 * **CI Passing:** All CI checks must pass before requesting review
 
+### Definition of Done — The Merge Loop
+
+A PR is not "done" when the code is written. It is done when it has run the full
+loop below and merged green. Follow these steps **in order** for every PR:
+
+1. **Run the full local gate first.** Run `make ci` (the authoritative gate, in
+   the right member directory for a workspace — see
+   [arch-06_monorepo_workspace_standards.md](../architecture/arch-06_monorepo_workspace_standards.md)
+   §3) before pushing. A partial check (`typecheck` + `lint` only) is not enough —
+   run the build and coverage too.
+2. **Open the PR and push.** CI runs; automated reviewers (see §7) fire on open.
+3. **Wait for the automated review to post.** Do not merge before it has run.
+4. **Address every comment.** All automated-reviewer findings and all human
+   "must fix" / "should fix" feedback are resolved or explicitly answered.
+5. **Get to all-green.** *Green means every required check passes.* A partial pass
+   is a fail — "3 of 4 checks passed" is not mergeable until the 4th passes (or is
+   justified and waived by policy). Resolve merge conflicts (a conflicting PR may
+   run **no** checks at all — see
+   [proc-02_git_version_control_standards.md](./proc-02_git_version_control_standards.md)
+   §11).
+6. **Merge** (squash-and-merge + delete branch is the default) **and clean up**
+   the branch/worktree.
+
+This loop is the single most important review convention: *open → automated review
+fires → address all feedback → all checks green → merge.* Never merge on a partial
+pass or before the automated review has run.
+
 ### Review Assignment
 
 * **Automatic:** Use CODEOWNERS file for automatic assignment
@@ -50,7 +77,11 @@
 - [ ] **TDD was followed** — tests were written before implementation (check commit order)
 - [ ] Includes appropriate tests (unit, integration, E2E, regression)
 - [ ] **Test coverage is ≥ 95%** in every modified module (100% for domain)
+- [ ] Coverage was met by **real tests**, not by adding dead/unreachable branches to hit a number; genuinely untestable boundaries follow the untestable-boundary policy (see [core-standards.md](../shared/core-standards.md) Testing Standards) rather than being faked
 - [ ] Bug fixes include a regression test that reproduces the original bug
+- [ ] No soft-deleted / tombstoned records leak out of read paths (a `get` that returns deleted rows)
+- [ ] Post-write side effects (cache invalidation, change notifications, index refresh, conflict/version stamping) are not skipped on any write path
+- [ ] Secondary/best-effort work (mirrors, sync, telemetry) is error-isolated so one failure does not void the primary result (see [arch-05](../architecture/arch-05_resilient_architecture_patterns.md) §7)
 - [ ] **Python code is fully typed** — `mypy --strict` passes with zero errors
 - [ ] Documentation is updated (code comments, README, user docs)
 - [ ] No P0/P1 security violations (see `standards/security/sec-01_security_standards.md`)
@@ -169,7 +200,8 @@ How was this tested?
 ### Merge Requirements
 
 * **Minimum Approvals:** At least one approval (configurable per project)
-* **CI Passing:** All CI checks must pass
+* **CI Passing:** *All* CI checks pass — green means every required check, not a partial pass
+* **Automated Review Addressed:** The automated reviewer (§7) has run and every finding is resolved or answered
 * **No Blocking Comments:** All "must fix" feedback addressed
 * **Up to Date:** Branch is up to date with target branch
 
@@ -209,11 +241,31 @@ How was this tested?
 * **Security:** Dependency vulnerability scanning, SAST (language-appropriate: bandit, eslint-plugin-security, brakeman, SpotBugs), secrets scanning
 * **Coverage:** Code coverage reporting
 
-### Bot Reviews
+### Automated Reviewers (Including AI Review)
 
-* **Dependency Updates:** Automated PRs for dependency updates
-* **Code Quality:** Automated code quality checks (CodeClimate, SonarQube)
-* **Documentation:** Automated documentation generation and validation
+Many repositories configure an **automated PR reviewer** (e.g. GitHub Copilot
+review, Coderabbit, or another AI/code-quality bot) that posts findings when a PR
+is opened. Where one is configured, treat it as a **first-class gate**, not a
+nicety:
+
+* **It fires automatically on PR open** — do not manually request it, and do not
+  merge before it has run and posted.
+* **Every finding is resolved or explicitly answered** before merge, the same as
+  human "must fix" feedback (see §5 Merge Requirements).
+* Other automated reviewers cover dependency updates (Dependabot/Renovate) and
+  code-quality/documentation checks (SonarQube, CodeClimate).
+
+The recurring findings such reviewers catch make a useful **author self-review
+checklist** before pushing:
+
+- Dead / unreachable branches (often added to chase a coverage number) — remove
+  them, don't ship them.
+- Soft-deleted / tombstoned records leaking out of read paths.
+- A write path that skips a post-write side effect (cache invalidation, change
+  notification, index refresh, version/conflict stamping).
+- Best-effort/secondary work that isn't error-isolated, so one failure voids the
+  whole operation.
+- Reused or copy-pasted identifiers/classes that should have been factored out.
 
 ### Human Review Still Required
 
@@ -240,12 +292,33 @@ How was this tested?
 
 ## 9. Special Cases
 
+### PR Scoping
+
+The goal is **one small, reviewable, independently mergeable PR per logical
+change**, sequenced deliberately — not a hard line count. The `< 400 lines`
+guideline is a smell threshold, not a law.
+
+* Prefer a chain of small PRs that each merge green over one large PR. When work
+  must be staged, **stack** PRs deliberately and mind the base-branch deletion
+  trap (see [proc-02_git_version_control_standards.md](./proc-02_git_version_control_standards.md)
+  §11 Stacked & Dependent PRs).
+* Don't over-split into PRs so small they aren't independently meaningful; group
+  trivially-coupled changes that must land together.
+
 ### Large PRs
 
 * **Split When Possible:** Break into smaller, focused PRs
 * **Extended Timeline:** Allow more time for review
 * **Incremental Review:** Review in sections if needed
 * **Documentation:** Provide detailed PR description and architecture notes
+
+### UI PRs
+
+* A UI change is **not auto-mergeable** without visual sign-off when no reference
+  design exists for the surface. Open the PR, attach the rendered screenshots, and
+  wait for human approval — even when CI is green. See
+  [proc-04_agent_workflow_standards.md](./proc-04_agent_workflow_standards.md) §7
+  (UI Change Validation).
 
 ### Refactoring PRs
 

--- a/standards/process/proc-04_agent_workflow_standards.md
+++ b/standards/process/proc-04_agent_workflow_standards.md
@@ -68,6 +68,33 @@ git worktree list            # should only show root checkout + active work
 git branch --no-merged main  # audit for abandoned branches
 ```
 
+### Worktree Hygiene
+
+The root checkout is the human's volatile workspace — it auto-pulls mainline and
+its branch gets switched out from under you. These rules keep agent work from
+landing on the wrong branch or failing on phantom errors:
+
+* **Do all multi-commit work in a worktree, never the root checkout.** If you must
+  touch the root, run `git branch --show-current` immediately before *every*
+  commit — a background pull may have flipped HEAD to `main` or another branch.
+* **`gh pr create` infers the head branch from the current directory.** Run it from
+  inside the feature worktree, or pass `--head <branch>` explicitly. Running it
+  from the root opens a PR for whatever branch the root is on — your title/body on
+  the wrong diff, a silent outward-facing mistake. Verify after:
+  `gh pr view <n> --json headRefName`. (`gh pr merge <number>` is safe — it takes
+  an explicit PR number.)
+* **Install from the lockfile in a fresh worktree before running gates.** A new
+  worktree shares the repo but not `node_modules`/`target`; a plain install can
+  resolve versions that differ from the committed lock and produce *phantom* lint
+  or type failures on files you never touched. Use the frozen/locked mode
+  (`pnpm install --frozen-lockfile`, `npm ci`, `cargo build --locked`). When a gate
+  fails on an untouched file, check the installed toolchain version against the
+  lock *before* "fixing" the file.
+* **Repair git hooks after switching worktrees.** Hook installers can leave
+  `.git/hooks/*` pointing at a deleted worktree's path. If hooks misbehave, run the
+  repo's hook-repair target (e.g. `make hooks`) to rewrite them for the current
+  checkout.
+
 ## 2. Project-Level AI Guide
 
 Every project SHOULD have a `CLAUDE.md` (or equivalent agent guide) at the repository root. This file is distinct from `.cursorrules` or `.github/copilot-instructions.md` — it documents project-specific context that evolves during development.
@@ -248,6 +275,32 @@ Patterns are globs evaluated against repo-relative file paths. For changes that 
 - **Per-region delta**: cropped diffs for changed components only. Best for token / theme changes that touch many pages.
 
 The agent's output is a **diff artifact + a summary of what changed**. Approval is human-gated unless the project explicitly opts into pixel-diff gating (rare; document the threshold in `assets/designs/NOTES.md`).
+
+### UI PRs are not auto-mergeable without sign-off
+
+When a UI change has **no reference design** for the surface (a brand-new view, an
+exploratory layout), the agent MUST open the PR, attach the rendered screenshots,
+and **wait for human visual sign-off** — even when CI is green. Do not auto-merge.
+This is an explicit exception to the otherwise-autonomous merge loop in
+[proc-03_code_review_expectations.md](./proc-03_code_review_expectations.md) §1.
+State it in the PR body (e.g. "UI — needs visual sign-off, do not auto-merge").
+
+### Visual baselines are environment-specific
+
+Visual-regression baselines must be regenerated **on the CI runner**, not locally.
+Even a matching local container renders fractionally differently (font hinting,
+anti-aliasing) from the CI host, so locally-generated baselines fail the CI visual
+gate. Regenerate via the pipeline's own mechanism (e.g. a `workflow_dispatch` with
+an `update_snapshots` input that uploads the regenerated baselines as an artifact),
+then commit those. Visual changes remain human-gated.
+
+### Cross-platform UI scope
+
+For products that ship the same UX on multiple platforms, a UI change is assumed
+to apply to **every** platform unless scoped otherwise. Scope the issue/PR to cover
+web *and* each native shell, and keep shared data/logic single-sourced in the core.
+See [arch-07_cross_platform_shared_core_standards.md](../architecture/arch-07_cross_platform_shared_core_standards.md)
+§4.
 
 ### Cross-agent invocation
 

--- a/standards/shared/blocks/architecture-core.md
+++ b/standards/shared/blocks/architecture-core.md
@@ -9,3 +9,5 @@ SOLID principles mandatory. Violations require justification in code comments.
 Validate inputs at boundaries. Fail fast; reject invalid state immediately.
 Define typed custom errors in Domain. No generic exceptions.
 Use structured logging with request ID, user ID, and operation context.
+Secondary/derived subsystems (mirrors, indexes, sync, telemetry) are best-effort and error-isolated — a failure there must never break the primary write path.
+When you catch-and-degrade, preserve and surface the original cause; never swallow it behind a generic "failed" message.

--- a/standards/shared/blocks/git-workflow.md
+++ b/standards/shared/blocks/git-workflow.md
@@ -1,8 +1,11 @@
 Conventional Commits: `type(scope): subject` — types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `ci`.
 Subject: imperative mood, ≤50 characters, no period.
 Branch naming: `type/description` in kebab-case (e.g., `feature/user-authentication`, `fix/email-validation`).
-One task = one branch = one PR. Work is not done until a PR exists.
+One task = one branch = one PR. Work is not done until a PR exists. Prefer small, independently mergeable PRs, sequenced/stacked deliberately.
 Feature branches from `main`. No direct pushes to `main`. Require one approval; all CI checks must pass.
+PR merge loop: run the full local gate (`make ci`) first → open PR → wait for the automated reviewer → address every finding → all checks green (a partial pass is a fail) → squash-merge + delete branch. Never merge on a partial pass or before the automated review runs.
+Run `gh pr create` from the feature worktree (or pass `--head`); the cwd's branch is what it opens.
+Stacked PRs: retarget dependents to `main` before merging+deleting a base branch, or the dependents get closed.
 Delete branches immediately after merge. Keep fewer than 10 active branches.
 Never commit: secrets, build artifacts, `node_modules/`, `.env`, IDE files, OS files.
 Always commit lock files (`package-lock.json`, `Gemfile.lock`, `Cargo.lock`, `uv.lock`).

--- a/standards/shared/blocks/testing-policy.md
+++ b/standards/shared/blocks/testing-policy.md
@@ -7,6 +7,6 @@ Coverage enforced in CI — blocks merge if violated:
 
 Every bug fix must include a regression test.
 Meet coverage with real tests — never add dead/unreachable branches to hit a number. For genuinely untestable boundaries (real filesystem/keychain/native APIs), keep the boundary thin, push logic into pure testable units, and flag the residual manual-verification step explicitly.
-Run the build (e.g. `tsc -b`), not just typecheck — the build checks test files and project references that `--noEmit` skips.
+Run the build (e.g. `tsc -b`), not just typecheck — a narrow typecheck config often excludes test files and the project references that the full build compiles, so the build catches errors typecheck misses.
 Mirror source structure: `src/domain/user.py` → `tests/domain/test_user.py`
 Use descriptive test names: `test_should_raise_error_when_email_is_invalid`

--- a/standards/shared/blocks/testing-policy.md
+++ b/standards/shared/blocks/testing-policy.md
@@ -6,5 +6,7 @@ Coverage enforced in CI — blocks merge if violated:
 - Infrastructure: 95%+
 
 Every bug fix must include a regression test.
+Meet coverage with real tests — never add dead/unreachable branches to hit a number. For genuinely untestable boundaries (real filesystem/keychain/native APIs), keep the boundary thin, push logic into pure testable units, and flag the residual manual-verification step explicitly.
+Run the build (e.g. `tsc -b`), not just typecheck — the build checks test files and project references that `--noEmit` skips.
 Mirror source structure: `src/domain/user.py` → `tests/domain/test_user.py`
 Use descriptive test names: `test_should_raise_error_when_email_is_invalid`

--- a/standards/shared/core-standards.md
+++ b/standards/shared/core-standards.md
@@ -121,6 +121,23 @@ Projects MUST build testing infrastructure that supports:
 
 Coverage gates MUST be enforced in CI. A PR that drops coverage below 95% in any module MUST NOT be merged.
 
+### Untestable Boundaries
+
+Some runtime surfaces genuinely cannot run in CI — a real filesystem-access API,
+a device keychain, a native window server, a third-party SDK with no test mode.
+The coverage floor is met with **real tests**, never by gaming the number.
+
+- **Keep the untestable boundary thin.** Push all logic *behind* it into pure,
+  testable units (the parsing, the decision, the transformation) and cover those
+  fully. The thin remaining adapter is the only part that can't be unit-tested.
+- **Never add dead or unreachable branches to hit a coverage target.** That is the
+  opposite of the goal — it ships untested code paths *and* hides the real gap, and
+  automated reviewers will (correctly) flag it.
+- **Flag the residual manual-verification step explicitly** — in the PR body and,
+  for agents, as a tracked item — rather than pretending the boundary is covered.
+- Document the exclusion (and why) where the project records coverage policy, so
+  the carve-out is auditable rather than silent.
+
 ### Test Organization
 
 - Mirror source structure: `src/domain/user.py` → `tests/domain/test_user.py`
@@ -321,6 +338,9 @@ Reference architecture pattern standards in:
 
 - `standards/architecture/arch-04_data_versioning_and_migration_standards.md`
 - `standards/architecture/arch-05_resilient_architecture_patterns.md`
+- `standards/architecture/arch-06_monorepo_workspace_standards.md`
+- `standards/architecture/arch-07_cross_platform_shared_core_standards.md`
+- `standards/architecture/arch-08_ci_cd_pipeline_standards.md`
 
 ## Security Standards
 


### PR DESCRIPTION
## Summary

Adds three new architecture standards and reinforces several process docs, all derived from recurring friction observed building a real multi-app, multi-platform monorepo (the amicus suite). Net-new guidance that the existing standards didn't cover, plus targeted edits where lived experience contradicted or under-specified a rule.

## New standards

- **`arch-06` Monorepo & Workspace Standards** — separate toolchains kept separate; per-member pipeline ownership ("own your scope, not your style"); **run the build, not just typecheck** (`tsc -b` checks test files `--noEmit` skips); complete alias/path resolution across every resolver; generated-artifact drift gates (clean-rebuild to reproduce); workspace dependency hygiene.
- **`arch-07` Cross-Platform Shared-Core Standards** — shared pure core + thin per-platform shells; **conformance / golden-vector testing as the parity gate**; FFI boundary coverage (export smoke / golden parity / edge cases); UI-changes-are-cross-platform-by-default scoping.
- **`arch-08` CI/CD Pipeline Standards** — local gate mirrors CI; consolidate the required gate + build once; concurrency-cancel, path filters, tiered heavy suites; caching with pinned actions + eviction; artifact retention; self-hosted runner caveats; deploy channels & promotion.

## Reinforcing edits

- **`proc-03`** — PR Definition-of-Done merge loop; automated/AI review treated as a first-class gate with an author self-review checklist; UI-PR sign-off case.
- **`proc-02`** — release-version vs build-version, deploy channels, scripted release cut (§5); Stacked & Dependent PRs + platform-automation traps (§11).
- **`proc-04`** — Worktree Hygiene (volatile root, `gh pr create` cwd, frozen-lockfile install, hook repair); UI sign-off, environment-specific visual baselines, cross-platform UI scope.
- **`arch-02`** — `make hooks` target; stronger `make dev` provisioning.
- **`arch-05` §§7-9** — best-effort/isolated secondary subsystems; coordination-singleton liveness/takeover; don't-swallow-the-cause.
- **`core-standards`** — Untestable Boundaries policy + references to the new docs.
- **Shared blocks** (`git-workflow`, `testing-policy`, `architecture-core`) updated so the lessons propagate into assembled agent configs.
- Index updates: CHANGELOG, README, STRUCTURE, CLAUDE.

## Notes

- Rebased onto `main` after #92/#98/#99/#100 landed; the CHANGELOG `[Unreleased]` block now carries both #88–#91 (#92) and this PR's `### Added` entries.
- Standards docs only — no scripts or app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
