### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- Add entries under the standard Keep a Changelog headings as work lands:
+### Added / ### Changed / ### Deprecated / ### Removed / ### Fixed / ### Security -->
+
 ## [1.3.0] - 2026-06-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-18
+
 ### Changed
 
 - **Documentation / releases (`proc-01 §4`, `shared/blocks/documentation-policy.md`):** projects with release automation (semantic-release, release-please, Changesets) must NOT hand-maintain a shared `## [Unreleased]` changelog block per PR — rely on generated notes or per-PR changeset fragments (avoids predictable merge conflicts under parallel work). (#88)


### PR DESCRIPTION
Cuts **v1.3.0**.

Promotes the `[Unreleased]` CHANGELOG block to `## [1.3.0] - 2026-06-18` and opens a fresh empty `[Unreleased]`. No standards content changes — changelog only.

### Included in 1.3.0
- New architecture standards: `arch-06` (monorepo/workspace), `arch-07` (cross-platform shared-core), `arch-08` (CI/CD pipeline).
- Process/architecture refinements: `proc-02` (release model + stacked-PR traps), `proc-03` (PR definition-of-done + AI review gate), `proc-04` (worktree hygiene + UI sign-off), `arch-05` (resilient secondary subsystems), `core-standards` (untestable boundaries).
- `#88-#91`: doc-policy automated-release guidance, `make test-e2e`/`make verify`, TypeScript runtime-enforcement and anti-brittleness test rules.
- Shared blocks + index updates so the lessons propagate into assembled agent configs.

After merge: tag `v1.3.0` on main and publish the GitHub release.

> Note: the highest existing tag is `v1.1.0`; the CHANGELOG's `[1.2.0]` section (PR #77, commit 298d64e) was finalized but never tagged. Flagging separately — happy to backfill the `v1.2.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)