### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Add entries under the standard Keep a Changelog headings as work lands:
 ### Added / ### Changed / ### Deprecated / ### Removed / ### Fixed / ### Security -->
 
+## [1.3.1] - 2026-06-18
+
+### Fixed
+
+- **Release hygiene:** backfilled the `v1.2.0` git tag and GitHub release (CHANGELOG `[1.2.0]`, PR #77, commit `298d64e`) that were finalized in the changelog but never published — restoring a contiguous tag/release history (previously jumped `v1.1.0` → `v1.3.0`).
+
 ## [1.3.0] - 2026-06-18
 
 ### Changed


### PR DESCRIPTION
Cuts **v1.3.1** — a release-hygiene patch.

Documents the **v1.2.0 backfill**: the `v1.2.0` git tag and GitHub release (CHANGELOG `[1.2.0]`, PR #77, commit `298d64e`) were finalized in the changelog but never published. Now tagged + released, so the history is contiguous (`v1.1.0` → `v1.2.0` → `v1.3.0` → `v1.3.1`).

Changelog-only. After merge: tag `v1.3.1` on main and publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)