### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Add entries under the standard Keep a Changelog headings as work lands:
 ### Added / ### Changed / ### Deprecated / ### Removed / ### Fixed / ### Security -->
 
+## [1.4.0] - 2026-06-18
+
 ### Changed
 
 - **Hosting:** migrated the documentation site from GitHub Pages to **Cloudflare Pages** via Cloudflare's **GitHub integration** (no API tokens/secrets in the repo). Cloudflare's production branch is `live`; a secret-free `publish.yml` (using `GITHUB_TOKEN`) fast-forwards `live` only on a **release cut** or a **new/edited blog post**, so the site republishes on exactly those events — not on every docs/standards merge. Drops the GitHub Pages `CNAME` marker and adds CF Pages `_headers`. Fixes the cross-provider TLS failure (GitHub ACME `bad_authz` behind the Cloudflare proxy → HTTP 526). Dashboard setup is documented in `docs/deploy.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Hosting:** migrated the documentation site from GitHub Pages to **Cloudflare Pages** via Cloudflare's **GitHub integration** (no API tokens/secrets in the repo). Cloudflare's production branch is `live`; a secret-free `publish.yml` (using `GITHUB_TOKEN`) fast-forwards `live` only on a **release cut** or a **new/edited blog post**, so the site republishes on exactly those events — not on every docs/standards merge. Drops the GitHub Pages `CNAME` marker and adds CF Pages `_headers`. Fixes the cross-provider TLS failure (GitHub ACME `bad_authz` behind the Cloudflare proxy → HTTP 526). Dashboard setup is documented in `docs/deploy.md`.
-- **CI:** the website CI build installs with `npm ci` (frozen lockfile) instead of `rm -rf node_modules package-lock.json && npm install`, and the committed `website/package-lock.json` was regenerated so it builds cleanly — reproducible builds (per the frozen-install standard in `arch-02`/`core-standards`), and Cloudflare's build uses the same lockfile.
+- **Hosting:** migrated the documentation site from GitHub Pages to **Cloudflare Pages** via Cloudflare's **GitHub integration** (no API tokens/secrets in the repo). Cloudflare's production branch is `live`; a secret-free `publish.yml` (using `GITHUB_TOKEN`) fast-forwards `live` only on a **release cut** or a **new/edited blog post**, so the site republishes on exactly those events — not on every docs/standards merge. Drops the GitHub Pages `CNAME` marker and adds CF Pages `_headers`. Fixes the cross-provider TLS failure (GitHub ACME `bad_authz` behind the Cloudflare proxy → HTTP 526). Dashboard setup is documented in `docs/deploy.md`. (#104)
+- **CI:** the website CI build installs with `npm ci` (frozen lockfile) instead of `rm -rf node_modules package-lock.json && npm install`, and the committed `website/package-lock.json` was regenerated so it builds cleanly — reproducible builds (per the frozen-install standard in `arch-02`/`core-standards`), and Cloudflare's build uses the same lockfile. (#104)
 
 ## [1.3.1] - 2026-06-18
 


### PR DESCRIPTION
Cuts **v1.4.0**. Changelog-only — promotes `[Unreleased]` to `## [1.4.0] - 2026-06-18` and opens a fresh `[Unreleased]`.

### In 1.4.0
- **Hosting:** docs site moved to **Cloudflare Pages** via Git integration (no secrets); publishes only on a release cut or blog-post change via the `live` branch + `publish.yml`. Fixes the HTTP 526 TLS error. (#104)
- **CI:** website build uses `npm ci` (frozen lockfile); committed lockfile regenerated to build cleanly. (#104)

After merge: tag `v1.4.0` + publish the GitHub release — which fires `publish.yml` and fast-forwards `live` (harmless until the Cloudflare dashboard is connected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)