### PR TITLE
fix(scripts): shell-script bug fixes from full-repo audit (#132, #133, #131, #130, #129, #142)

### DIFF
--- a/bin/gh-task
+++ b/bin/gh-task
@@ -99,10 +99,15 @@ load_config() {
         done < "$CONFIG_FILE"
     fi
     
-    # Get repository info
-    REPO_OWNER=$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || echo "")
-    REPO_NAME=$(gh repo view --json name --jq '.name' 2>/dev/null || echo "")
-    
+    # Fall back to `gh repo view` only when the config didn't supply the values,
+    # so the documented REPO_OWNER/REPO_NAME config keys are actually honored.
+    if [ -z "${REPO_OWNER:-}" ]; then
+        REPO_OWNER=$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || echo "")
+    fi
+    if [ -z "${REPO_NAME:-}" ]; then
+        REPO_NAME=$(gh repo view --json name --jq '.name' 2>/dev/null || echo "")
+    fi
+
     if [ -z "$REPO_OWNER" ] || [ -z "$REPO_NAME" ]; then
         error "Could not determine repository information"
     fi
@@ -120,10 +125,22 @@ EOF
 }
 
 # Load current task state
+# Parse as key=value data with a whitelist of expected keys. Never `source`
+# the file: it lives in the working directory (.gh-task-state) and a tampered
+# or mis-merged copy would otherwise execute arbitrary shell code.
 load_state() {
-    if [ -f "$STATE_FILE" ]; then
-        source "$STATE_FILE"
-    fi
+    [ -f "$STATE_FILE" ] || return 0
+    local key value
+    while IFS='=' read -r key value; do
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$key" ]] && continue
+        key=$(echo "$key" | xargs)
+        case "$key" in
+            CURRENT_ISSUE)  CURRENT_ISSUE="$value"  ;;
+            CURRENT_BRANCH) CURRENT_BRANCH="$value" ;;
+            STARTED_AT)     STARTED_AT="$value"     ;;
+        esac
+    done < "$STATE_FILE"
 }
 
 # Clear task state
@@ -405,7 +422,8 @@ cmd_create() {
     fi
     
     # Extract issue number from URL
-    local issue_number=$(echo "$issue_url" | grep -oP '\d+$')
+    # Portable extraction: BSD grep (macOS default) has no -P/PCRE support.
+    local issue_number=$(echo "$issue_url" | grep -Eo '[0-9]+$')
     
     success "Created issue #$issue_number"
     echo "$issue_url"
@@ -579,8 +597,11 @@ cmd_submit() {
         git checkout "$CURRENT_BRANCH" || error "Failed to checkout branch"
     fi
     
-    # Check for uncommitted changes
-    if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+    # Check for uncommitted changes.
+    # `git diff-index HEAD` errors on a repo with no commits (HEAD unresolved),
+    # which would otherwise be misreported as "uncommitted changes". Only run
+    # the diff once we know HEAD resolves.
+    if git rev-parse --verify -q HEAD >/dev/null 2>&1 && ! git diff-index --quiet HEAD -- 2>/dev/null; then
         warning "You have uncommitted changes"
         git status --short
         echo ""
@@ -650,9 +671,17 @@ This PR addresses the work tracked in issue #$CURRENT_ISSUE.
 ---
 *Created via gh-task CLI*"
     
+    # Resolve the issue title up front so a failed lookup doesn't silently
+    # create a PR with an empty title.
+    local pr_title
+    pr_title=$(gh issue view "$CURRENT_ISSUE" --json title --jq '.title' 2>/dev/null || echo "")
+    if [ -z "$pr_title" ]; then
+        error "Could not fetch title for issue #$CURRENT_ISSUE — aborting PR creation"
+    fi
+
     local pr_url=$(gh pr create \
         --draft \
-        --title "$(gh issue view "$CURRENT_ISSUE" --json title --jq '.title')" \
+        --title "$pr_title" \
         --body "$pr_body" 2>/dev/null || echo "")
     
     if [ -z "$pr_url" ]; then

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@
 #   STANDARDS_REPO_URL="https://github.com/c65llc/coding-standards" \
 #     curl -fsSL https://raw.githubusercontent.com/c65llc/coding-standards/main/install.sh | bash
 
-set -e
+set -euo pipefail
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -35,9 +35,21 @@ cd "$PROJECT_ROOT"
 # Check if standards already exist
 if [ -d "$STANDARDS_DIR" ]; then
     echo -e "${YELLOW}⚠️  Standards directory already exists at $STANDARDS_DIR${NC}"
-    read -p "Continue anyway? (y/N) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    # Under the documented `curl ... | bash` flow, stdin IS the piped script, so
+    # a bare `read` would consume script bytes instead of user input. Read from
+    # the controlling terminal explicitly, and support a non-interactive opt-in.
+    if [ "${STANDARDS_ASSUME_YES:-}" = "1" ]; then
+        echo "   STANDARDS_ASSUME_YES=1 set — continuing without prompt."
+    elif [ -r /dev/tty ]; then
+        read -p "Continue anyway? (y/N) " -n 1 -r < /dev/tty
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Aborted."
+            exit 1
+        fi
+    else
+        echo -e "${YELLOW}   No interactive terminal detected (piped install).${NC}"
+        echo -e "${YELLOW}   Re-run with STANDARDS_ASSUME_YES=1 to proceed non-interactively.${NC}"
         echo "Aborted."
         exit 1
     fi
@@ -61,11 +73,16 @@ else
         rm -rf "$STANDARDS_DIR"
     fi
     git clone "$STANDARDS_REPO_URL" "$STANDARDS_DIR"
+    INSTALL_MODE="clone"
     echo -e "${GREEN}✅ Standards cloned${NC}"
+    echo -e "${YELLOW}   Note: installed as a plain clone, NOT a git submodule.${NC}"
+    echo -e "${YELLOW}   'git submodule update' will not manage $STANDARDS_DIR;${NC}"
+    echo -e "${YELLOW}   update it with: git -C $STANDARDS_DIR pull${NC}"
 fi
+INSTALL_MODE="${INSTALL_MODE:-submodule}"
 
-# Initialize submodule if needed
-if [ -f "$STANDARDS_DIR/.gitmodules" ] || [ -f "$PROJECT_ROOT/.gitmodules" ]; then
+# Initialize submodule if needed (skip for plain-clone installs)
+if [ "$INSTALL_MODE" = "submodule" ] && [ -f "$PROJECT_ROOT/.gitmodules" ]; then
     git submodule update --init --recursive "$STANDARDS_DIR" 2>/dev/null || true
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -41,9 +41,10 @@ if [ -d "$STANDARDS_DIR" ]; then
     if [ "${STANDARDS_ASSUME_YES:-}" = "1" ]; then
         echo "   STANDARDS_ASSUME_YES=1 set — continuing without prompt."
     elif [ -r /dev/tty ]; then
-        read -p "Continue anyway? (y/N) " -n 1 -r < /dev/tty
+        REPLY=""
+        read -p "Continue anyway? (y/N) " -n 1 -r < /dev/tty || true
         echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        if [[ ! "${REPLY:-}" =~ ^[Yy]$ ]]; then
             echo "Aborted."
             exit 1
         fi

--- a/scripts/diff-standards.sh
+++ b/scripts/diff-standards.sh
@@ -34,31 +34,11 @@ if [ -f "$SCRIPT_DIR/lib/checksums.sh" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Map languages to block filenames (shared logic)
+# Map languages to block filenames (shared: scripts/lib/languages.sh)
 # ---------------------------------------------------------------------------
 
-map_languages_to_blocks() {
-    local BLOCKS=()
-    for lang in $1; do
-        case "$lang" in
-            python)     BLOCKS+=("lang-python.md") ;;
-            javascript) BLOCKS+=("lang-javascript.md") ;;
-            typescript) BLOCKS+=("lang-typescript.md") ;;
-            jvm)        BLOCKS+=("lang-java.md" "lang-kotlin.md") ;;
-            java)       BLOCKS+=("lang-java.md") ;;
-            kotlin)     BLOCKS+=("lang-kotlin.md") ;;
-            ruby)       BLOCKS+=("lang-ruby.md") ;;
-            rails)      BLOCKS+=("lang-rails.md" "lang-ruby.md") ;;
-            rust)       BLOCKS+=("lang-rust.md") ;;
-            swift)      BLOCKS+=("lang-swift.md") ;;
-            dart)       BLOCKS+=("lang-dart.md") ;;
-            zig)        BLOCKS+=("lang-zig.md") ;;
-            go)         BLOCKS+=("lang-go.md") ;;
-            elixir)     BLOCKS+=("lang-elixir.md") ;;
-        esac
-    done
-    printf '%s\n' "${BLOCKS[@]}" | sort -u | tr '\n' ' '
-}
+# shellcheck source=lib/languages.sh
+source "$SCRIPT_DIR/lib/languages.sh"
 
 # ---------------------------------------------------------------------------
 # Locate standards directories

--- a/scripts/diff-standards.sh
+++ b/scripts/diff-standards.sh
@@ -37,7 +37,7 @@ fi
 # Map languages to block filenames (shared: scripts/lib/languages.sh)
 # ---------------------------------------------------------------------------
 
-# shellcheck source=lib/languages.sh
+# shellcheck source=lib/languages.sh disable=SC1091
 source "$SCRIPT_DIR/lib/languages.sh"
 
 # ---------------------------------------------------------------------------

--- a/scripts/generate-pr-content.sh
+++ b/scripts/generate-pr-content.sh
@@ -2,7 +2,7 @@
 # Generate PR content using git information for Cursor AI to enhance
 # This script outputs PR information that Cursor AI can use to generate better titles and descriptions
 
-set -e
+set -euo pipefail
 
 CURRENT_BRANCH=$(git branch --show-current)
 BASE_BRANCH="${1:-main}"
@@ -19,9 +19,13 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 STANDARDS_TMP_DIR="$PROJECT_ROOT/.standards_tmp"
 mkdir -p "$STANDARDS_TMP_DIR"
 
-# Create temporary file for PR content in .standards_tmp
+# Create a file for PR content in .standards_tmp (gitignored, ephemeral).
+# NOTE: This file is intentionally NOT deleted on exit — line ~59 prints its
+# path to stdout so a downstream consumer (the Cursor `/pr` command, `make pr`)
+# can read it after this script returns. An EXIT trap that removed it would
+# delete the file before any consumer could open it. Cleanup is left to the
+# ephemeral .standards_tmp/ directory.
 PR_CONTENT_FILE="$STANDARDS_TMP_DIR/pr-content-$(date +%s)-$$.txt"
-trap 'rm -f "$PR_CONTENT_FILE"' EXIT
 
 # Gather commit information
 {

--- a/scripts/lib/dry-run.sh
+++ b/scripts/lib/dry-run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Dry-run aware file operations shared by setup.sh and sync-standards.sh.
+#
+# These helpers read the global DRY_RUN variable at call time: when DRY_RUN is
+# "true" they print what would happen and make no changes; otherwise they
+# perform the operation. Callers must define DRY_RUN (true|false) before use.
+#
+# Usage:
+#   source "$SCRIPT_DIR/lib/dry-run.sh"
+#   DRY_RUN=false
+#   dry_run_cp src dst
+#   printf '...' | dry_run_write dst
+
+dry_run_cp() {
+    if [ "${DRY_RUN:-false}" = true ]; then
+        echo "  [dry-run] Would copy: $1 → $2"
+    else
+        cp "$1" "$2"
+    fi
+}
+
+dry_run_mkdir() {
+    if [ "${DRY_RUN:-false}" = true ]; then
+        echo "  [dry-run] Would create directory: $1"
+    else
+        mkdir -p "$1"
+    fi
+}
+
+dry_run_write() {
+    local target="$1"
+    if [ "${DRY_RUN:-false}" = true ]; then
+        echo "  [dry-run] Would write: $target"
+        cat > /dev/null
+    else
+        cat > "$target"
+    fi
+}
+
+dry_run_append() {
+    local target="$1"
+    if [ "${DRY_RUN:-false}" = true ]; then
+        echo "  [dry-run] Would append to: $target"
+        cat > /dev/null
+    else
+        cat >> "$target"
+    fi
+}

--- a/scripts/lib/languages.sh
+++ b/scripts/lib/languages.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Language → standards-block mapping shared by setup.sh, sync-standards.sh, and
+# diff-standards.sh.
+#
+# This is the single source of truth for how detected language keys map to the
+# lang-*.md block filenames assembled into agent configs. When a new language
+# standard is added, update ONLY this table.
+#
+# Usage:
+#   source "$SCRIPT_DIR/lib/languages.sh"
+#   blocks=$(map_languages_to_blocks "python typescript go")
+
+# Map detected languages to block filenames.
+map_languages_to_blocks() {
+    local BLOCKS=()
+    for lang in $1; do
+        case "$lang" in
+            python)     BLOCKS+=("lang-python.md") ;;
+            javascript) BLOCKS+=("lang-javascript.md") ;;
+            typescript) BLOCKS+=("lang-typescript.md") ;;
+            jvm)        BLOCKS+=("lang-java.md" "lang-kotlin.md") ;;
+            java)       BLOCKS+=("lang-java.md") ;;
+            kotlin)     BLOCKS+=("lang-kotlin.md") ;;
+            ruby)       BLOCKS+=("lang-ruby.md") ;;
+            rails)      BLOCKS+=("lang-rails.md" "lang-ruby.md") ;;
+            rust)       BLOCKS+=("lang-rust.md") ;;
+            swift)      BLOCKS+=("lang-swift.md") ;;
+            dart)       BLOCKS+=("lang-dart.md") ;;
+            zig)        BLOCKS+=("lang-zig.md") ;;
+            go)         BLOCKS+=("lang-go.md") ;;
+            elixir)     BLOCKS+=("lang-elixir.md") ;;
+        esac
+    done
+    # Deduplicate and output space-separated on one line.
+    if [ ${#BLOCKS[@]} -gt 0 ]; then
+        printf '%s\n' "${BLOCKS[@]}" | sort -u | tr '\n' ' '
+    fi
+}

--- a/scripts/lint-standards.sh
+++ b/scripts/lint-standards.sh
@@ -208,6 +208,7 @@ output_json() {
     printf '  "results": [\n'
 
     local first=true
+    if [ ${#RESULTS[@]} -gt 0 ]; then
     for result in "${RESULTS[@]}"; do
         local status check_name message
         status=$(echo "$result" | awk '{print $1}')
@@ -229,6 +230,7 @@ output_json() {
         printf '      "message": "%s"\n' "$message"
         printf '    }'
     done
+    fi
 
     printf '\n  ]\n'
     printf '}\n'
@@ -268,15 +270,18 @@ output_sarif() {
     # Emit rules array from unique check names
     local rules_first=true
     local seen_rules=()
+    if [ ${#RESULTS[@]} -gt 0 ]; then
     for result in "${RESULTS[@]}"; do
         local check_name
         check_name=$(echo "$result" | awk '{print $2}')
 
         # Skip duplicates
         local already_seen=false
+        if [ ${#seen_rules[@]} -gt 0 ]; then
         for seen in "${seen_rules[@]}"; do
             [ "$seen" = "$check_name" ] && already_seen=true && break
         done
+        fi
         $already_seen && continue
         seen_rules+=("$check_name")
 
@@ -301,6 +306,7 @@ output_sarif() {
         printf '              "shortDescription": { "text": "Standards compliance check: %s" }\n' "$check_name"
         printf '            }'
     done
+    fi
 
     printf '\n          ]\n'
     printf '        }\n'
@@ -308,6 +314,7 @@ output_sarif() {
     printf '      "results": [\n'
 
     local results_first=true
+    if [ ${#RESULTS[@]} -gt 0 ]; then
     for result in "${RESULTS[@]}"; do
         local status check_name message level
         status=$(echo "$result" | awk '{print $1}')
@@ -342,6 +349,7 @@ output_sarif() {
         printf '          ]\n'
         printf '        }'
     done
+    fi
 
     printf '\n      ],\n'
     printf '      "invocations": [\n'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,42 +41,9 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# Dry-run aware file operations
-dry_run_cp() {
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would copy: $1 → $2"
-    else
-        cp "$1" "$2"
-    fi
-}
-
-dry_run_mkdir() {
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would create directory: $1"
-    else
-        mkdir -p "$1"
-    fi
-}
-
-dry_run_write() {
-    local target="$1"
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would write: $target"
-        cat > /dev/null
-    else
-        cat > "$target"
-    fi
-}
-
-dry_run_append() {
-    local target="$1"
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would append to: $target"
-        cat > /dev/null
-    else
-        cat >> "$target"
-    fi
-}
+# Dry-run aware file operations (shared: scripts/lib/dry-run.sh)
+# shellcheck source=lib/dry-run.sh
+source "$SCRIPT_DIR/lib/dry-run.sh"
 
 if [ "$DRY_RUN" = true ]; then
     echo "🔍 DRY RUN — showing what would change (no files modified)"
@@ -95,30 +62,9 @@ fi
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/assembly.sh"
 
-# Map detected languages to block filenames
-map_languages_to_blocks() {
-    local BLOCKS=()
-    for lang in $1; do
-        case "$lang" in
-            python)     BLOCKS+=("lang-python.md") ;;
-            javascript) BLOCKS+=("lang-javascript.md") ;;
-            typescript) BLOCKS+=("lang-typescript.md") ;;
-            jvm)        BLOCKS+=("lang-java.md" "lang-kotlin.md") ;;
-            java)       BLOCKS+=("lang-java.md") ;;
-            kotlin)     BLOCKS+=("lang-kotlin.md") ;;
-            ruby)       BLOCKS+=("lang-ruby.md") ;;
-            rails)      BLOCKS+=("lang-rails.md" "lang-ruby.md") ;;
-            rust)       BLOCKS+=("lang-rust.md") ;;
-            swift)      BLOCKS+=("lang-swift.md") ;;
-            dart)       BLOCKS+=("lang-dart.md") ;;
-            zig)        BLOCKS+=("lang-zig.md") ;;
-            go)         BLOCKS+=("lang-go.md") ;;
-            elixir)     BLOCKS+=("lang-elixir.md") ;;
-        esac
-    done
-    # Deduplicate and output
-    printf '%s\n' "${BLOCKS[@]}" | sort -u | tr '\n' ' '
-}
+# Map detected languages to block filenames (shared: scripts/lib/languages.sh)
+# shellcheck source=lib/languages.sh
+source "$SCRIPT_DIR/lib/languages.sh"
 
 # Function to setup AI agent configurations
 setup_ai_agents() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
 done
 
 # Dry-run aware file operations (shared: scripts/lib/dry-run.sh)
-# shellcheck source=lib/dry-run.sh
+# shellcheck source=lib/dry-run.sh disable=SC1091
 source "$SCRIPT_DIR/lib/dry-run.sh"
 
 if [ "$DRY_RUN" = true ]; then
@@ -63,7 +63,7 @@ fi
 source "$SCRIPT_DIR/lib/assembly.sh"
 
 # Map detected languages to block filenames (shared: scripts/lib/languages.sh)
-# shellcheck source=lib/languages.sh
+# shellcheck source=lib/languages.sh disable=SC1091
 source "$SCRIPT_DIR/lib/languages.sh"
 
 # Function to setup AI agent configurations

--- a/scripts/sync-standards.sh
+++ b/scripts/sync-standards.sh
@@ -22,7 +22,7 @@ while [ $# -gt 0 ]; do
 done
 
 # Dry-run aware file operations (shared: scripts/lib/dry-run.sh)
-# shellcheck source=lib/dry-run.sh
+# shellcheck source=lib/dry-run.sh disable=SC1091
 source "$SCRIPT_DIR/lib/dry-run.sh"
 
 if [ "$DRY_RUN" = true ]; then
@@ -50,7 +50,7 @@ fi
 source "$SCRIPT_DIR/lib/assembly.sh"
 
 # Map detected languages to block filenames (shared: scripts/lib/languages.sh)
-# shellcheck source=lib/languages.sh
+# shellcheck source=lib/languages.sh disable=SC1091
 source "$SCRIPT_DIR/lib/languages.sh"
 
 # Function to sync AI agent configurations

--- a/scripts/sync-standards.sh
+++ b/scripts/sync-standards.sh
@@ -21,42 +21,9 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# Dry-run aware file operations
-dry_run_cp() {
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would copy: $1 → $2"
-    else
-        cp "$1" "$2"
-    fi
-}
-
-dry_run_mkdir() {
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would create directory: $1"
-    else
-        mkdir -p "$1"
-    fi
-}
-
-dry_run_write() {
-    local target="$1"
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would write: $target"
-        cat > /dev/null
-    else
-        cat > "$target"
-    fi
-}
-
-dry_run_append() {
-    local target="$1"
-    if [ "$DRY_RUN" = true ]; then
-        echo "  [dry-run] Would append to: $target"
-        cat > /dev/null
-    else
-        cat >> "$target"
-    fi
-}
+# Dry-run aware file operations (shared: scripts/lib/dry-run.sh)
+# shellcheck source=lib/dry-run.sh
+source "$SCRIPT_DIR/lib/dry-run.sh"
 
 if [ "$DRY_RUN" = true ]; then
     echo "🔍 DRY RUN — showing what would change (no files modified)"
@@ -82,30 +49,9 @@ fi
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/assembly.sh"
 
-# Map detected languages to block filenames (shared with setup.sh)
-map_languages_to_blocks() {
-    local BLOCKS=()
-    for lang in $1; do
-        case "$lang" in
-            python)     BLOCKS+=("lang-python.md") ;;
-            javascript) BLOCKS+=("lang-javascript.md") ;;
-            typescript) BLOCKS+=("lang-typescript.md") ;;
-            jvm)        BLOCKS+=("lang-java.md" "lang-kotlin.md") ;;
-            java)       BLOCKS+=("lang-java.md") ;;
-            kotlin)     BLOCKS+=("lang-kotlin.md") ;;
-            ruby)       BLOCKS+=("lang-ruby.md") ;;
-            rails)      BLOCKS+=("lang-rails.md" "lang-ruby.md") ;;
-            rust)       BLOCKS+=("lang-rust.md") ;;
-            swift)      BLOCKS+=("lang-swift.md") ;;
-            dart)       BLOCKS+=("lang-dart.md") ;;
-            zig)        BLOCKS+=("lang-zig.md") ;;
-            go)         BLOCKS+=("lang-go.md") ;;
-            elixir)     BLOCKS+=("lang-elixir.md") ;;
-        esac
-    done
-    # Deduplicate and output
-    printf '%s\n' "${BLOCKS[@]}" | sort -u | tr '\n' ' '
-}
+# Map detected languages to block filenames (shared: scripts/lib/languages.sh)
+# shellcheck source=lib/languages.sh
+source "$SCRIPT_DIR/lib/languages.sh"
 
 # Function to sync AI agent configurations
 sync_ai_agents() {


### PR DESCRIPTION
Resolves six shell-script issues surfaced in the July 2026 full-repo audit. Grouped into one PR per the agreed batch strategy.

## Fixes

- **#132** `lint-standards.sh` crashed on `--format json`/`--format sarif` with **zero findings** under bash 3.2 (`set -u` + empty-array expansion) — the exact path the `standards-review` composite action runs. Guarded all three output loops plus the `seen_rules` dedup loop, and validated JSON/SARIF output.
- **#133** `gh-task` `source`d the working-directory `.gh-task-state` file (arbitrary code execution). Now parsed as whitelisted `key=value` data. Also: honor the documented `REPO_OWNER`/`REPO_NAME` config keys (previously dead), handle a repo with no commits, and abort instead of opening a PR with an empty title on a failed issue-title lookup.
- **#129** `gh-task` used `grep -oP` (no PCRE on macOS BSD grep) → issue-number extraction silently returned empty on the primary dev platform. Replaced with portable `grep -Eo '[0-9]+$'`.
- **#131** `generate-pr-content.sh` set an `EXIT` trap that deleted the output file before any consumer could read the path it printed to stdout. Dropped the trap (file lives in gitignored `.standards_tmp/`); added `set -euo pipefail`.
- **#130** `install.sh` `read -p` consumed piped script bytes under `curl | bash`. Now reads from `/dev/tty` with a `STANDARDS_ASSUME_YES=1` non-interactive opt-in; warns when a plain-clone fallback diverges from submodule mode; `set -euo pipefail`.
- **#142** Deduped `map_languages_to_blocks` (3 copies) and the `dry_run_*` helpers (2 copies) into `scripts/lib/languages.sh` and `scripts/lib/dry-run.sh`, sourced from `setup.sh`, `sync-standards.sh`, `diff-standards.sh`.

## Verification

- `make test-scripts` ✅ · `scripts/test-gh-task.sh` (12/12) ✅
- `bash -n` on all changed scripts ✅
- Zero-findings `--format json`/`--format sarif` now emit valid JSON (verified with `python3 -c json.load`)
- `setup.sh --dry-run` / `diff-standards.sh` smoke-run clean; no stray files written
- Shared-lib functions verified for populated and empty inputs

Closes #132
Closes #133
Closes #131
Closes #130
Closes #129
Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)