### PR TITLE
docs: fix commit-taxonomy conflict, --workflow docs, and agent-config drift (#138, #143, #136)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -9,7 +9,11 @@ Reference and strictly follow these documents when making any changes:
 1. **Architecture & Standards:**
    - `standards/architecture/arch-01_project_standards_and_architecture.md` - Core architecture, SOLID principles, naming conventions
    - `standards/architecture/arch-02_automation_standards.md` - Makefile targets and automation requirements
-   - `standards/architecture/arch-03_cursor_automation_standards.md` - Cursor-specific interaction modes (@new-feature, @refactor, @debug, @review)
+   - `standards/architecture/arch-04_data_versioning_and_migration_standards.md` - Data versioning and migration
+   - `standards/architecture/arch-05_resilient_architecture_patterns.md` - Resilient architecture patterns
+   - `standards/architecture/arch-06_monorepo_workspace_standards.md` - Monorepo/workspace structure
+   - `standards/architecture/arch-07_cross_platform_shared_core_standards.md` - Cross-platform shared-core
+   - `standards/architecture/arch-08_ci_cd_pipeline_standards.md` - CI/CD pipeline
 
 2. **Language-Specific Standards:**
    - `standards/languages/lang-01_python_standards.md` - Python (uv, ruff, mypy, pytest)
@@ -23,11 +27,14 @@ Reference and strictly follow these documents when making any changes:
    - `standards/languages/lang-09_zig_standards.md` - Zig (zig build, zig fmt, manual memory management)
    - `standards/languages/lang-10_ruby_standards.md` - Ruby (bundler, rubocop, sorbet, rspec)
    - `standards/languages/lang-11_ruby_on_rails_standards.md` - Ruby on Rails (Rails 7.2+, rubocop-rails)
+   - `standards/languages/lang-12_go_standards.md` - Go (go build, gofmt, go vet, table-driven tests)
+   - `standards/languages/lang-13_elixir_standards.md` - Elixir (mix, mix format, credo, ExUnit)
 
 3. **Process Standards:**
    - `standards/process/proc-01_documentation_standards.md` - ADR, code docs, changelog, user docs
    - `standards/process/proc-02_git_version_control_standards.md` - Git workflow, commits, branching
    - `standards/process/proc-03_code_review_expectations.md` - Code review process and expectations
+   - `standards/process/proc-04_agent_workflow_standards.md` - Agent worktree/PR workflow
 
 4. **Security Standards:**
    - `standards/security/sec-01_security_standards.md` - Security guidelines with P0-P2 severity model
@@ -52,7 +59,7 @@ These mandates apply to ALL code changes, regardless of scope or urgency:
    - Documentation → `standards/process/proc-01_documentation_standards.md`
    - Git operations → `standards/process/proc-02_git_version_control_standards.md`
 
-2. **Follow interaction modes** from `standards/architecture/arch-03_cursor_automation_standards.md`:
+2. **Follow interaction modes:**
    - `@new-feature` - Scaffold new features following Clean Architecture
    - `@refactor` - Apply SOLID principles and naming conventions
    - `@debug` - Systematic debugging approach
@@ -89,6 +96,8 @@ When working with code, automatically detect the language and apply the correspo
 - `.zig` files → `standards/languages/lang-09_zig_standards.md`
 - `.rb` files → `standards/languages/lang-10_ruby_standards.md`
 - `.erb` files, `Gemfile`, `Rakefile` → `standards/languages/lang-11_ruby_on_rails_standards.md`
+- `.go` files, `go.mod` → `standards/languages/lang-12_go_standards.md`
+- `.ex`, `.exs` files, `mix.exs` → `standards/languages/lang-13_elixir_standards.md`
 
 ## Response Style
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -106,8 +106,12 @@ When working with this repository, agents must follow the A-P-E (Analyze, Plan, 
 
 - **Architecture:** `standards/architecture/arch-01_project_standards_and_architecture.md`
 - **Automation:** `standards/architecture/arch-02_automation_standards.md`
-- **Cursor Integration:** `standards/architecture/arch-03_cursor_automation_standards.md`
-- **Language Standards:** `standards/languages/lang-01_python_standards.md` through `lang-11_ruby_on_rails_standards.md`
+- **Data Versioning & Migration:** `standards/architecture/arch-04_data_versioning_and_migration_standards.md`
+- **Resilient Architecture:** `standards/architecture/arch-05_resilient_architecture_patterns.md`
+- **Monorepo/Workspace:** `standards/architecture/arch-06_monorepo_workspace_standards.md`
+- **Cross-Platform Shared Core:** `standards/architecture/arch-07_cross_platform_shared_core_standards.md`
+- **CI/CD Pipeline:** `standards/architecture/arch-08_ci_cd_pipeline_standards.md`
+- **Language Standards:** `standards/languages/lang-01_python_standards.md` through `lang-13_elixir_standards.md`
 - **Process Standards:** `standards/process/proc-01_documentation_standards.md` through `proc-04_agent_workflow_standards.md`
 - **Security Standards:** `standards/security/sec-01_security_standards.md` - P0-P2 security guidelines
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,10 +9,15 @@ This project follows comprehensive development standards. Reference these docume
 ### Architecture & Standards
 - `standards/architecture/arch-01_project_standards_and_architecture.md` - Core architecture, SOLID principles, naming conventions
 - `standards/architecture/arch-02_automation_standards.md` - Makefile targets and automation requirements
+- `standards/architecture/arch-04_data_versioning_and_migration_standards.md` - Data versioning and migration
+- `standards/architecture/arch-05_resilient_architecture_patterns.md` - Resilient architecture patterns
+- `standards/architecture/arch-06_monorepo_workspace_standards.md` - Monorepo/workspace standards
+- `standards/architecture/arch-07_cross_platform_shared_core_standards.md` - Cross-platform shared-core standards
+- `standards/architecture/arch-08_ci_cd_pipeline_standards.md` - CI/CD pipeline standards
 - `standards/shared/core-standards.md` - Shared core standards
 
 ### Language-Specific Standards
-- `standards/languages/lang-01_python_standards.md` - Python (poetry/uv, black, ruff, mypy, pytest)
+- `standards/languages/lang-01_python_standards.md` - Python (uv, ruff, mypy, pytest)
 - `standards/languages/lang-02_java_standards.md` - Java (Gradle/Maven, Java 17+, JUnit 5)
 - `standards/languages/lang-03_kotlin_standards.md` - Kotlin (Gradle, ktlint, detekt, MockK)
 - `standards/languages/lang-04_swift_standards.md` - Swift (SPM, swiftformat, XCTest)
@@ -23,6 +28,8 @@ This project follows comprehensive development standards. Reference these docume
 - `standards/languages/lang-09_zig_standards.md` - Zig (zig build, zig fmt, manual memory management)
 - `standards/languages/lang-10_ruby_standards.md` - Ruby (bundler, rubocop, sorbet, rspec)
 - `standards/languages/lang-11_ruby_on_rails_standards.md` - Ruby on Rails (Rails 7.2+, rubocop-rails)
+- `standards/languages/lang-12_go_standards.md` - Go (go modules, gofmt, go vet, golangci-lint)
+- `standards/languages/lang-13_elixir_standards.md` - Elixir (mix, mix format, credo, ExUnit)
 
 ### Process Standards
 - `standards/process/proc-01_documentation_standards.md` - ADR, code docs, changelog, user docs
@@ -83,6 +90,8 @@ When working with code, automatically detect the language and apply the correspo
 - `.zig` files → `standards/languages/lang-09_zig_standards.md`
 - `.rb` files → `standards/languages/lang-10_ruby_standards.md`
 - `.erb` files, `Gemfile`, `Rakefile` → `standards/languages/lang-11_ruby_on_rails_standards.md`
+- `.go` files, `go.mod` → `standards/languages/lang-12_go_standards.md`
+- `.ex`, `.exs` files, `mix.exs` → `standards/languages/lang-13_elixir_standards.md`
 
 ## Response Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Use `--dry-run` with setup or sync to preview changes without modifying files:
 ./scripts/sync-standards.sh --dry-run
 ```
 
-The standards-review composite GitHub Action lives at `.github/actions/standards-review/action.yml`. It runs `lint-standards.sh --format json` and posts structured PR comments. A ready-to-use workflow template is at `templates/standards-review.yml.example`. Installing it into a consumer project is **opt-in**: run `setup.sh --workflow` to copy it to `.github/workflows/standards-review.yml`. Without `--workflow`, setup only prints how to install it.
+The standards-review composite GitHub Action lives at `.github/actions/standards-review/action.yml`. It runs `lint-standards.sh --format json` and posts structured PR comments. A ready-to-use workflow template is at `templates/standards-review.yml.example`. Installing it into a consumer project is **opt-in**: run `.standards/scripts/setup.sh --workflow` (or `./scripts/setup.sh --workflow` from a clone of this repo) to copy it to `.github/workflows/standards-review.yml`. Without `--workflow`, setup only prints how to install it.
 
 There are no build steps, no test suites, and no application to run. The primary "tests" are `bash -n` syntax checks on shell scripts.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Use `--dry-run` with setup or sync to preview changes without modifying files:
 ./scripts/sync-standards.sh --dry-run
 ```
 
-The standards-review composite GitHub Action lives at `.github/actions/standards-review/action.yml`. It runs `lint-standards.sh --format json` and posts structured PR comments. A ready-to-use workflow template is at `templates/standards-review.yml.example` — `setup.sh` copies it to `.github/workflows/standards-review.yml` in consumer projects automatically.
+The standards-review composite GitHub Action lives at `.github/actions/standards-review/action.yml`. It runs `lint-standards.sh --format json` and posts structured PR comments. A ready-to-use workflow template is at `templates/standards-review.yml.example`. Installing it into a consumer project is **opt-in**: run `setup.sh --workflow` to copy it to `.github/workflows/standards-review.yml`. Without `--workflow`, setup only prints how to install it.
 
 There are no build steps, no test suites, and no application to run. The primary "tests" are `bash -n` syntax checks on shell scripts.
 
@@ -47,15 +47,17 @@ Markdown files organized by category with prefix-based naming:
 ### Agent Configurations (`standards/agents/`)
 
 Template configs deployed to consumer projects during setup:
+- `claude-code/base-claude-code.md` — Claude Code (assembled to `CLAUDE.md`)
+- `cursor/` — Cursor AI (assembled to `.cursorrules`)
 - `copilot/.github/copilot-instructions.md` — GitHub Copilot
-- `aider/.aiderrc` — Aider (Claude Code)
-- `codex/.codexrc` — OpenAI Codex
+- `aider/.aiderrc` — Aider
+- OpenAI Codex reads `AGENTS.md` at the project root (the legacy `codex/.codexrc` is deprecated)
 - Gemini CLI config lives at `.gemini/` (root level, per Gemini convention)
 
 ### Scripts (`scripts/`)
 
 All bash. Key scripts:
-- `setup.sh` — Installs standards into a target project, detects and configures AI agents; also copies the standards-review workflow template
+- `setup.sh` — Installs standards into a target project, detects and configures AI agents; copies the standards-review workflow template only when run with `--workflow`
 - `sync-standards.sh` — Pulls latest standards and updates agent configs in consumer projects
 - `lint-standards.sh` — Standards compliance linter; outputs text, JSON, or SARIF
 - `add-copilot-instructions-pr.sh` — Creates a PR to add Copilot instructions to a repo
@@ -70,7 +72,7 @@ All bash. Key scripts:
 - **Standards numbering**: Files use category-based prefixes (arch-XX, lang-XX, proc-XX). Preserve this naming scheme when adding new standards.
 - **Conventional Commits**: `type(scope): subject` — types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `ci`
 - **Temporary files**: Go in `.standards_tmp/` (gitignored).
-- **Agent config consistency**: When modifying shared standards in `core-standards.md`, check that agent configs (`.cursorrules`, copilot-instructions.md, `.aiderrc`, `.codexrc`, `GEMINI.md`) stay aligned.
+- **Agent config consistency**: When modifying shared standards in `core-standards.md`, check that agent configs (`CLAUDE.md`, `.cursorrules`, copilot-instructions.md, `.aiderrc`, `AGENTS.md`, `GEMINI.md`) stay aligned.
 - **Shell scripts**: Must pass `bash -n` syntax validation.
 - **Safety**: Never modify `.standards_tmp/`, `.secret`, or `.tfstate` files. Always preserve standards file numbering. Update `.cursorrules` when adding new standards.
 - **Safe setup (1.2+)**: `setup.sh` never clobbers existing agent configs. Customized files are staged to `.standards-pending/` with a `MERGE_PLAN.md` describing how to reconcile them. The merge skill (`/merge-standards` in Claude Code / Cursor, `make merge-standards` via CLI) drives the agent-agnostic handoff.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Python, Java, Kotlin, Swift, Dart, TypeScript, JavaScript, Rust, Zig, Ruby, Ruby
 - **Auto-Updating** -- Git hooks keep standards in sync whenever you pull.
 - **Preview Before You Commit** -- `--dry-run` flag for `setup.sh` and `sync-standards.sh` shows every write operation without modifying files. `make diff-standards` shows line-level diffs for all agent configs.
 - **Standards Compliance Linter** -- `make lint-standards` checks commits, secrets, coverage, type safety, and banned functions across Python, TypeScript, Go, and Elixir. Outputs text, JSON, or SARIF for GitHub Code Scanning.
-- **Automated PR Review** -- A composite GitHub Action posts structured standards compliance results as a PR comment on every pull request. Installed automatically by `make setup`; blocks merge when checks fail.
+- **Automated PR Review** -- A composite GitHub Action posts structured standards compliance results as a PR comment on every pull request. Opt-in: install the workflow with `./setup.sh --workflow`; blocks merge when checks fail.
 - **GitHub Project Lifecycle** -- CLI-driven workflow connecting issues to Draft PRs via GitHub Projects V2.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Python, Java, Kotlin, Swift, Dart, TypeScript, JavaScript, Rust, Zig, Ruby, Ruby
 - **Auto-Updating** -- Git hooks keep standards in sync whenever you pull.
 - **Preview Before You Commit** -- `--dry-run` flag for `setup.sh` and `sync-standards.sh` shows every write operation without modifying files. `make diff-standards` shows line-level diffs for all agent configs.
 - **Standards Compliance Linter** -- `make lint-standards` checks commits, secrets, coverage, type safety, and banned functions across Python, TypeScript, Go, and Elixir. Outputs text, JSON, or SARIF for GitHub Code Scanning.
-- **Automated PR Review** -- A composite GitHub Action posts structured standards compliance results as a PR comment on every pull request. Opt-in: install the workflow with `./setup.sh --workflow`; blocks merge when checks fail.
+- **Automated PR Review** -- A composite GitHub Action posts structured standards compliance results as a PR comment on every pull request. Opt-in: install the workflow with `.standards/scripts/setup.sh --workflow` (or `./scripts/setup.sh --workflow` from a clone of this repo); blocks merge when checks fail.
 - **GitHub Project Lifecycle** -- CLI-driven workflow connecting issues to Draft PRs via GitHub Projects V2.
 
 ## Documentation

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -34,7 +34,9 @@ This document explains the reorganized file hierarchy for easier navigation and 
 │   │   ├── lang-08_rust_standards.md
 │   │   ├── lang-09_zig_standards.md
 │   │   ├── lang-10_ruby_standards.md
-│   │   └── lang-11_ruby_on_rails_standards.md
+│   │   ├── lang-11_ruby_on_rails_standards.md
+│   │   ├── lang-12_go_standards.md
+│   │   └── lang-13_elixir_standards.md
 │   │
 │   ├── process/                   # Process & workflow standards
 │   │   ├── proc-01_documentation_standards.md
@@ -50,7 +52,7 @@ This document explains the reorganized file hierarchy for easier navigation and 
 │   │
 │   └── agents/                    # AI agent-specific configurations
 │       ├── claude-code/
-│       │   ├── CLAUDE.md.template
+│       │   ├── base-claude-code.md
 │       │   ├── settings.json.example
 │       │   └── permissions/       # Language-specific Claude Code permissions
 │       │       ├── python.txt
@@ -60,7 +62,9 @@ This document explains the reorganized file hierarchy for easier navigation and 
 │       │       ├── jvm.txt
 │       │       ├── swift.txt
 │       │       ├── dart.txt
-│       │       └── zig.txt
+│       │       ├── zig.txt
+│       │       ├── go.txt
+│       │       └── elixir.txt
 │       ├── python/
 │       │   └── ruff.toml          # Python linter/formatter config
 │       ├── rust/
@@ -75,7 +79,7 @@ This document explains the reorganized file hierarchy for easier navigation and 
 │       │       └── copilot-instructions.md
 │       ├── aider/
 │       │   └── .aiderrc
-│       ├── codex/
+│       ├── codex/                 # Note: Codex now reads AGENTS.md at project root (.codexrc is deprecated)
 │       │   └── .codexrc
 │       └── gemini/                # Note: Gemini CLI uses .gemini/ at root (Gemini CLI convention)
 │           └── (configs in .gemini/ at project root)

--- a/docs/getting-started/project-structure.md
+++ b/docs/getting-started/project-structure.md
@@ -27,7 +27,11 @@ This document explains the repository layout so you can find what you need quick
 │   ├── architecture/               # Architecture and automation standards
 │   │   ├── arch-01_project_standards_and_architecture.md
 │   │   ├── arch-02_automation_standards.md
-│   │   └── arch-03_cursor_automation_standards.md
+│   │   ├── arch-04_data_versioning_and_migration_standards.md
+│   │   ├── arch-05_resilient_architecture_patterns.md
+│   │   ├── arch-06_monorepo_workspace_standards.md
+│   │   ├── arch-07_cross_platform_shared_core_standards.md
+│   │   └── arch-08_ci_cd_pipeline_standards.md
 │   │
 │   ├── languages/                  # Language-specific standards
 │   │   ├── lang-01_python_standards.md
@@ -40,7 +44,9 @@ This document explains the repository layout so you can find what you need quick
 │   │   ├── lang-08_rust_standards.md
 │   │   ├── lang-09_zig_standards.md
 │   │   ├── lang-10_ruby_standards.md
-│   │   └── lang-11_ruby_on_rails_standards.md
+│   │   ├── lang-11_ruby_on_rails_standards.md
+│   │   ├── lang-12_go_standards.md
+│   │   └── lang-13_elixir_standards.md
 │   │
 │   ├── process/                    # Process and workflow standards
 │   │   ├── proc-01_documentation_standards.md
@@ -52,12 +58,15 @@ This document explains the repository layout so you can find what you need quick
 │   │   └── core-standards.md
 │   │
 │   └── agents/                     # AI agent configuration templates
+│       ├── claude-code/            # → assembled to CLAUDE.md
+│       │   └── base-claude-code.md
+│       ├── cursor/                 # → assembled to .cursorrules
 │       ├── copilot/
 │       │   └── .github/
 │       │       └── copilot-instructions.md
 │       ├── aider/
 │       │   └── .aiderrc
-│       └── codex/
+│       └── codex/                  # legacy; Codex now reads AGENTS.md at root
 │           └── .codexrc
 │
 ├── scripts/                        # Automation scripts

--- a/docs/guides/multi-agent-setup.md
+++ b/docs/guides/multi-agent-setup.md
@@ -5,16 +5,17 @@ description: "Configure multiple AI coding assistants to follow the same project
 
 # Multi-Agent Setup
 
-This repository supports five AI coding assistants out of the box. Every agent reads the same underlying standards, so your team gets consistent suggestions regardless of which tool each person uses.
+This repository supports six AI coding assistants out of the box. Every agent reads the same underlying standards, so your team gets consistent suggestions regardless of which tool each person uses.
 
 ## Supported Agents
 
 | Agent | Config File | Location |
 | ----- | ----------- | -------- |
+| Claude Code | `CLAUDE.md` | Project root |
 | Cursor AI | `.cursorrules` | Project root |
 | GitHub Copilot | `.github/copilot-instructions.md` | `.github/` directory |
-| Aider / Claude Code | `.aiderrc` | Project root |
-| OpenAI Codex | `.codexrc` | Project root |
+| Aider | `.aiderrc` | Project root |
+| OpenAI Codex | `AGENTS.md` | Project root |
 | Gemini CLI / Antigravity | `.gemini/GEMINI.md`, `.gemini/settings.json` | `.gemini/` directory |
 
 ## Automatic Setup
@@ -41,6 +42,12 @@ Any agent configuration that has not been applied yet is added automatically dur
 
 ## Agent-Specific Details
 
+### Claude Code
+
+- **Config:** `CLAUDE.md` in your project root.
+- **How it works:** Claude Code reads `CLAUDE.md` automatically when you run `claude` in the project directory, using it as project-specific guidance. Language-aware permissions and settings are written to `.claude/`.
+- **After setup:** No restart needed; the config is read on each invocation. Customize `CLAUDE.md` with your project's specifics.
+
 ### Cursor AI
 
 - **Config:** `.cursorrules` in your project root.
@@ -62,7 +69,7 @@ To add Copilot instructions to an existing repo via a pull request:
 make add-copilot-instructions
 ```
 
-### Aider / Claude Code
+### Aider
 
 - **Config:** `.aiderrc` in your project root.
 - **How it works:** Aider reads `.aiderrc` automatically when you run `aider` in the project directory.
@@ -71,8 +78,8 @@ make add-copilot-instructions
 
 ### OpenAI Codex
 
-- **Config:** `.codexrc` in your project root.
-- **How it works:** Codex-compatible tools read this file for project-specific guidance.
+- **Config:** `AGENTS.md` in your project root. (The older `.codexrc` is deprecated; if present it is preserved but no longer the source of truth.)
+- **How it works:** Codex reads `AGENTS.md` for project-specific guidance.
 - **After setup:** Check your IDE's Codex integration documentation.
 
 ### Gemini CLI and Google Antigravity
@@ -100,7 +107,7 @@ After setup, verify each agent is working:
 
 ```bash
 # Check that config files exist
-ls -la .cursorrules .github/copilot-instructions.md .aiderrc .codexrc .gemini/GEMINI.md .gemini/settings.json
+ls -la CLAUDE.md .cursorrules .github/copilot-instructions.md .aiderrc AGENTS.md .gemini/GEMINI.md .gemini/settings.json
 ```
 
 Then ask each agent to generate a small piece of code and confirm it follows the project's naming conventions and architecture rules.

--- a/standards/README.md
+++ b/standards/README.md
@@ -11,7 +11,7 @@ This directory contains all coding standards documents organized by category.
 | `process/` | `proc-XX` | Documentation, git workflow, code review, agent workflow |
 | `security/` | `sec-XX` | Security guidelines with P0-P2 severity model |
 | `shared/` | — | Cross-cutting standards (`core-standards.md`) referenced by all agent configs |
-| `agents/` | — | Template configs for AI coding assistants (Copilot, Aider, Codex, Gemini) |
+| `agents/` | — | Template configs for AI coding assistants (Claude Code, Cursor, Copilot, Aider, Codex, Gemini) |
 
 ## Naming Convention
 
@@ -30,7 +30,7 @@ When adding new standards, use the next available number in the appropriate cate
 Atomic content fragments used to assemble agent configs at setup time. Each block is a condensed summary (~5-20 lines) of standards content, written in imperative style for token-efficient agent consumption.
 
 - **Common blocks** (always included): architecture-core, testing-policy, security-summary, naming-conventions, git-workflow, documentation-policy
-- **Language blocks** (per detection): lang-python, lang-typescript, lang-javascript, lang-java, lang-kotlin, lang-swift, lang-dart, lang-rust, lang-zig, lang-ruby, lang-rails
+- **Language blocks** (per detection): lang-python, lang-typescript, lang-javascript, lang-java, lang-kotlin, lang-swift, lang-dart, lang-rust, lang-zig, lang-ruby, lang-rails, lang-go, lang-elixir
 - **Role blocks** (one per project): role-service, role-library, role-app, role-data-pipeline
 
 ## Agent Base Templates (`agents/`)

--- a/standards/process/proc-02_git_version_control_standards.md
+++ b/standards/process/proc-02_git_version_control_standards.md
@@ -14,8 +14,15 @@
 ### Branch Naming
 
 * **Format:** `type/description` (kebab-case)
-* **Types:** `feature`, `fix`, `hotfix`, `release`, `refactor`, `docs`, `test`
+* **Branch prefixes:** `feature`, `fix`, `hotfix`, `release`, `refactor`, `docs`, `test`
 * **Description:** Concise, descriptive (3-5 words)
+
+> **Branch prefixes are not commit types.** The words above name *branches*
+> (`feature/user-auth`, `hotfix/security-patch`). Commit **messages** use the
+> Conventional Commits types below — note `feat`, not `feature`, and there is no
+> `hotfix`/`release` commit type. The canonical commit-type set is defined once
+> in `shared/core-standards.md` (§ Commit Messages); this document must stay
+> aligned with it.
 
 ## 2. Commit Messages
 
@@ -31,16 +38,22 @@
 
 ### Commit Types
 
+The canonical cross-cutting set (from `shared/core-standards.md`) is:
+`feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `ci`.
+
 * **feat:** New feature
 * **fix:** Bug fix
-* **docs:** Documentation changes
-* **style:** Code style changes (formatting, missing semicolons)
 * **refactor:** Code refactoring (no functional changes)
-* **perf:** Performance improvements
 * **test:** Adding or updating tests
+* **docs:** Documentation changes
 * **chore:** Maintenance tasks (dependencies, build config)
+* **perf:** Performance improvements
 * **ci:** CI/CD changes
-* **build:** Build system changes
+
+Additional Conventional Commits types the linter also accepts
+(`scripts/lint-checks/common/conventional-commits.sh`) but which fall outside
+the canonical set: `build` (build-system changes), `style` (formatting-only
+changes), `revert` (reverting a prior commit). Prefer the canonical types.
 
 ### Commit Guidelines
 


### PR DESCRIPTION
Batch 2 of the full-repo-audit cleanup: documentation/standards consistency. One PR per the agreed batch strategy.

## #138 — proc-02 commit-type taxonomy vs Conventional Commits
`proc-02`'s line-17 list (`feature, fix, hotfix, release, …`) reads as commit types but is really *branch prefixes*. Disambiguated: branch prefixes (`feature/…`, `hotfix/…`) are explicitly distinguished from commit types (`feat`, not `feature`; no `hotfix`/`release` commit type). Pinned the canonical commit-type set to `core-standards.md` and documented the extra types the linter also accepts (`build`/`style`/`revert`).

## #143 — "setup installs the workflow automatically"
`setup.sh` only copies the standards-review workflow with `--workflow`; the default path just prints how to install it. Corrected `CLAUDE.md` and `README.md` to describe it as opt-in.

## #136 — agent configs / docs drifted from the standards tree
- Removed all references to the **deleted arch-03**; added **arch-04..arch-08** across `.cursorrules`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`, `docs/getting-started/project-structure.md`.
- Added **Go (lang-12)** and **Elixir (lang-13)** to every config's standards list and language-detection map, and to the `STRUCTURE.md` / `standards/README.md` / `project-structure.md` trees.
- Fixed stale Python tooling `poetry/uv, black, ruff` → `uv, ruff, mypy`.
- Reflected that **Codex reads `AGENTS.md`** (legacy `codex/.codexrc` deprecated) in `CLAUDE.md`, `STRUCTURE.md`, `multi-agent-setup.md`, `project-structure.md`.
- Fixed `claude-code/CLAUDE.md.template` → `base-claude-code.md`; added `go.txt`/`elixir.txt` permissions; added a standalone **Claude Code** agent section; listed `claude-code/`+`cursor/` where they were omitted.

The durable fix (generating these lists from the tree with a CI drift gate) is tracked separately in #137.

## Verification
- All referenced filenames verified against the actual `standards/` tree.
- `grep -rn arch-03` over live configs/docs returns only historical blog/plan/spec files (intentionally left as dated records).
- `bash -n` n/a (docs-only). No code paths touched.

Closes #138
Closes #143
Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)