### PR TITLE
ci: harden workflows, expand coverage, pin actions, release automation (#128, #127, #108, #134, #135, #141)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,54 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Categorize the drafted release notes. PRs are auto-labeled below from their
+# Conventional Commit title, so contributors don't have to label by hand.
+categories:
+  - title: '🚀 Features'
+    labels: ['enhancement', 'feature']
+  - title: '🐛 Bug Fixes'
+    labels: ['bug', 'fix']
+  - title: '📝 Documentation'
+    labels: ['documentation']
+  - title: '🔧 Maintenance & Refactor'
+    labels: ['chore', 'refactor', 'ci', 'test', 'perf']
+  - title: '⬆️ Dependencies'
+    labels: ['dependencies']
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+# Map Conventional Commit PR titles onto the labels used above.
+autolabeler:
+  - label: 'feature'
+    title: ['/^feat(\(.+\))?!?:/']
+  - label: 'bug'
+    title: ['/^fix(\(.+\))?!?:/']
+  - label: 'documentation'
+    title: ['/^docs(\(.+\))?!?:/']
+  - label: 'ci'
+    title: ['/^ci(\(.+\))?!?:/']
+  - label: 'perf'
+    title: ['/^perf(\(.+\))?!?:/']
+  - label: 'test'
+    title: ['/^test(\(.+\))?!?:/']
+  - label: 'chore'
+    title: ['/^(chore|refactor|build)(\(.+\))?!?:/']
+
+# Pick the semver bump from labels; a `!` breaking-change PR should carry the
+# `breaking` label (added manually) to force a major bump.
+version-resolver:
+  major:
+    labels: ['major', 'breaking']
+  minor:
+    labels: ['minor', 'feature', 'enhancement']
+  patch:
+    labels: ['patch', 'bug', 'fix', 'documentation', 'chore', 'ci', 'test', 'perf', 'dependencies']
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,22 +8,36 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same ref so rapid pushes don't stack.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
 
       - name: Run ShellCheck on all shell scripts
+        # Cover the whole shell tree: top-level scripts, the sourced libs under
+        # scripts/lib/, every lint-check module, bin/gh-task, and the installer.
+        # --severity=warning + .shellcheckrc keep the gate meaningful without
+        # drowning in pre-existing style noise. -x follows sourced files.
         run: |
-          shellcheck scripts/*.sh install.sh
+          shellcheck -x --severity=warning \
+            scripts/*.sh \
+            scripts/lib/*.sh \
+            scripts/lint-checks/*/*.sh \
+            bin/gh-task \
+            install.sh
           if [ -d "website/scripts" ]; then
-            shellcheck website/scripts/*.sh
+            shellcheck -x --severity=warning website/scripts/*.sh
           fi
 
   test-scripts:
@@ -31,13 +45,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Syntax check (bash -n)
         run: make test-scripts
 
       - name: Bootstrap functional tests
         run: ./scripts/test-bootstrap.sh
+
+      - name: Safe-setup functional tests
+        run: ./scripts/test-setup-safe.sh
 
       - name: gh-task tests
         run: ./scripts/test-gh-task.sh
@@ -47,26 +64,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.12.0"
 
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli
 
-      - name: Run markdownlint on standards/ and docs/
+      - name: Run markdownlint on standards/, docs/, and root markdown
+        # REVIEW.md is a stale one-off scheduled for removal (#140); ignore it
+        # rather than block CI on its formatting.
         run: |
-          markdownlint 'standards/**/*.md' 'docs/**/*.md'
+          markdownlint 'standards/**/*.md' 'docs/**/*.md' '*.md' --ignore REVIEW.md
 
   build-website:
     name: Build Website
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Check if website directory exists
         id: check-website
@@ -79,7 +98,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.check-website.outputs.exists == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.12.0"
 
@@ -90,3 +109,31 @@ jobs:
       - name: Build website
         if: steps.check-website.outputs.exists == 'true'
         run: cd website && npm run build
+
+  lint-standards-selfhost:
+    name: Lint Standards (dogfood)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      # Dogfood our own compliance linter against this repo. This repo is a
+      # standards library, not an application, so it legitimately has no test
+      # dir / coverage config — we therefore do NOT fail on findings. Instead we
+      # assert the linter RUNS cleanly and emits valid JSON/SARIF. This is the
+      # exact contract the standards-review composite action depends on and
+      # would have caught the zero-findings crash fixed in #132.
+      - name: Run linter (text, informational)
+        run: ./scripts/lint-standards.sh . || true
+
+      - name: Assert --format json emits valid JSON (no crash)
+        run: |
+          set -euo pipefail
+          ./scripts/lint-standards.sh --format json . > /tmp/lint.json || true
+          python3 -c "import json,sys; json.load(open('/tmp/lint.json')); print('valid JSON')"
+
+      - name: Assert --format sarif emits valid JSON (no crash)
+        run: |
+          set -euo pipefail
+          ./scripts/lint-standards.sh --format sarif . > /tmp/lint.sarif || true
+          python3 -c "import json,sys; json.load(open('/tmp/lint.sarif')); print('valid SARIF')"

--- a/.github/workflows/definition-of-done.yml
+++ b/.github/workflows/definition-of-done.yml
@@ -10,7 +10,7 @@ on:
         description: 'Node.js version to use (if applicable)'
         required: false
         type: string
-        default: '18'
+        default: '22'
       python_version:
         description: 'Python version to use (if applicable)'
         required: false
@@ -36,6 +36,11 @@ on:
         description: 'GitHub token for API access'
         required: false
 
+# Serialize per calling ref so rapid pushes don't stack redundant DoD runs.
+concurrency:
+  group: definition-of-done-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-quality-checks:
     name: Code Quality & Standards
@@ -46,20 +51,20 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           
       - name: Setup Node.js
         if: hashFiles('package.json') != ''
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'npm'
           
       - name: Setup Python
         if: hashFiles('requirements.txt', 'setup.py', 'pyproject.toml') != ''
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ inputs.python_version }}
           
@@ -71,10 +76,13 @@ jobs:
         if: hashFiles('requirements.txt') != ''
         run: pip install -r requirements.txt
         
-      - name: Run linting
+      # Advisory: this reusable workflow runs against arbitrary consumer repos
+      # with unknown lint setups, so linting reports but does not fail the gate
+      # (note the `|| true`). Only the "Run tests" step is enforcing.
+      - name: Run linting (advisory — reports only, does not fail the gate)
         if: inputs.run_linting
         run: |
-          echo "Running linting checks..."
+          echo "Running linting checks (advisory)..."
           
           # Node.js linting
           if [ -f "package.json" ]; then
@@ -129,10 +137,10 @@ jobs:
           
           echo "✅ Tests passed"
           
-      - name: Check code coverage
+      - name: Check code coverage (advisory — reports only, does not fail the gate)
         if: inputs.run_tests
         run: |
-          echo "Checking code coverage..."
+          echo "Checking code coverage (advisory)..."
           
           # Node.js coverage
           if [ -f "package.json" ] && grep -q '"coverage"' package.json; then
@@ -160,11 +168,11 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         
-      - name: Run dependency security scan
+      - name: Run dependency security scan (advisory — reports only)
         run: |
-          echo "Running dependency security scan..."
+          echo "Running dependency security scan (advisory)..."
           
           # Node.js security audit
           if [ -f "package.json" ]; then
@@ -183,14 +191,14 @@ jobs:
           
           echo "✅ Security scan completed"
           
-      - name: Run CodeQL Analysis
-        uses: github/codeql-action/init@v4
+      - name: Run CodeQL Analysis (advisory — continue-on-error)
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: 'javascript,python'
         continue-on-error: true
-        
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+
+      - name: Perform CodeQL Analysis (advisory — continue-on-error)
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         continue-on-error: true
   
   documentation-checks:
@@ -201,7 +209,7 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         
       - name: Check for README updates
         run: |
@@ -241,7 +249,7 @@ jobs:
       
     steps:
       - name: Check PR details
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.gh_token || secrets.GITHUB_TOKEN }}
           script: |
@@ -298,7 +306,7 @@ jobs:
       
     steps:
       - name: Generate summary
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.gh_token || secrets.GITHUB_TOKEN }}
           script: |
@@ -327,13 +335,29 @@ jobs:
             }
             
             console.log(summary);
-            
-            // Post summary as comment if this is a PR
+
+            // Post/update the summary comment. Edit the previous DoD comment in
+            // place (matched by a hidden marker) instead of stacking a new
+            // comment on every run.
             if (context.payload.pull_request) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: summary
-              });
+              const marker = '<!-- definition-of-done-summary -->';
+              const body = `${marker}\n${summary}`;
+              const { owner, repo } = context.repo;
+              const issue_number = context.payload.pull_request.number;
+
+              const existing = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number, per_page: 100 }
+              );
+              const prior = existing.find(c => (c.body || '').includes(marker));
+
+              if (prior) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: prior.id, body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number, body
+                });
+              }
             }

--- a/.github/workflows/lifecycle-sync.yml
+++ b/.github/workflows/lifecycle-sync.yml
@@ -20,6 +20,11 @@ on:
         description: 'GitHub token with project write permissions'
         required: false
 
+# Serialize per calling ref so rapid PR events don't race project updates.
+concurrency:
+  group: lifecycle-sync-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   sync-project-status:
     name: Sync Project Status
@@ -31,11 +36,11 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -80,7 +85,7 @@ jobs:
       
       - name: Update project status
         if: steps.pr.outputs.issue_number != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           PROJECT_ID: ${{ inputs.project_id }}
           STATUS_FIELD_ID: ${{ inputs.status_field_id }}
@@ -112,21 +117,11 @@ jobs:
               const issueId = issue.data.node_id;
               console.log(`Issue node ID: ${issueId}`);
               
-              // Find the project item
-              const projectQuery = `
+              // Fetch the Status field options (fields are few; first 20 is safe).
+              const fieldsQuery = `
                 query($projectId: ID!) {
                   node(id: $projectId) {
                     ... on ProjectV2 {
-                      items(first: 100) {
-                        nodes {
-                          id
-                          content {
-                            ... on Issue {
-                              id
-                            }
-                          }
-                        }
-                      }
                       fields(first: 20) {
                         nodes {
                           ... on ProjectV2SingleSelectField {
@@ -143,22 +138,65 @@ jobs:
                   }
                 }
               `;
-              
-              const projectData = await github.graphql(projectQuery, {
+
+              const fieldsData = await github.graphql(fieldsQuery, {
                 projectId: projectId
               });
-              
-              // Find the project item for this issue
-              const projectItem = projectData.node.items.nodes.find(
-                item => item.content?.id === issueId
-              );
-              
+
+              // Find the project item for this issue by paginating ALL items.
+              // A non-paginated items(first: 100) silently fails to find the
+              // issue once the project exceeds 100 items (#135).
+              const itemsQuery = `
+                query($projectId: ID!, $cursor: String) {
+                  node(id: $projectId) {
+                    ... on ProjectV2 {
+                      items(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          id
+                          content {
+                            ... on Issue {
+                              id
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+
+              let projectItem = null;
+              let cursor = null;
+              let pageCount = 0;
+              do {
+                const page = await github.graphql(itemsQuery, {
+                  projectId: projectId,
+                  cursor: cursor
+                });
+                pageCount++;
+                const items = page.node.items;
+                projectItem = items.nodes.find(
+                  item => item.content?.id === issueId
+                );
+                cursor = items.pageInfo.hasNextPage ? items.pageInfo.endCursor : null;
+              } while (!projectItem && cursor);
+
+              // Reshape to keep the downstream code below unchanged.
+              const projectData = { node: { fields: fieldsData.node.fields } };
+
               if (!projectItem) {
-                console.log('Issue not found in project, skipping update');
+                // Fail loudly: surface a warning annotation so this gap is
+                // visible rather than silently skipped.
+                core.warning(
+                  `Issue #${issueNumber} not found in project after scanning ` +
+                  `${pageCount} page(s) of items — status was NOT updated. ` +
+                  `Verify the issue is added to the project.`
+                );
                 return;
               }
-              
-              console.log(`Project item ID: ${projectItem.id}`);
+
+              console.log(`Project item ID: ${projectItem.id} (found on page ${pageCount})`);
               
               // Find the Status field and target option
               const statusField = projectData.node.fields.nodes.find(

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the commit to publish
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # On a release, publish the tagged commit; otherwise the triggering
           # commit on main.
@@ -39,4 +39,17 @@ jobs:
           fetch-depth: 0
 
       - name: Fast-forward `live` (triggers the Cloudflare Pages build)
-        run: git push --force origin HEAD:live
+        # Use --force-with-lease so an out-of-band commit pushed to `live`
+        # between our read and our push is not silently clobbered. The checkout
+        # above only fetched the publish ref, so capture `live`'s current SHA
+        # explicitly and lease against it (creating `live` if it doesn't exist).
+        run: |
+          set -euo pipefail
+          LIVE_SHA="$(git ls-remote origin refs/heads/live | cut -f1)"
+          if [ -n "$LIVE_SHA" ]; then
+            echo "Leasing live against $LIVE_SHA"
+            git push --force-with-lease=live:"$LIVE_SHA" origin HEAD:live
+          else
+            echo "live does not exist yet — creating it"
+            git push origin HEAD:live
+          fi

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,12 @@ permissions:
 
 jobs:
   update_release_draft:
+    # Skip PRs from forks: their GITHUB_TOKEN is read-only, so autolabeling would
+    # fail and show a red check for external contributors. Drafting still runs on
+    # push to main and on same-repo PRs.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write      # create/update the draft release
       pull-requests: write # apply autolabels

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,32 @@
+name: Release Drafter
+
+# Keeps a draft GitHub Release continuously up to date from merged PRs, and
+# auto-labels PRs from their Conventional Commit title so the notes categorize
+# themselves. Publishing the draft creates the tag — that tag's `release:
+# published` event is what publish.yml and definition-of-done.yml already key
+# off of. This replaces the manual `chore(release)` note-writing.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write      # create/update the draft release
+      pull-requests: write # apply autolabels
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-drafter-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,24 @@
+# ShellCheck configuration for the coding-standards repo.
+#
+# CI lints the whole shell tree (scripts/, scripts/lib/, scripts/lint-checks/,
+# bin/gh-task, install.sh, website/scripts/). This config keeps that gate
+# meaningful — errors and substantive warnings still fail — while silencing a
+# small set of pervasive, low-value, or intentional findings so the expanded
+# scope doesn't drown real issues in style noise.
+
+# Follow `source`d files (shared libs under scripts/lib/) during analysis.
+external-sources=true
+
+# NOTE: severity is a CLI-only option (not valid in .shellcheckrc). CI runs
+# shellcheck with `--severity=warning` to drop info/style chatter
+# (e.g. SC2016 single-quoted GraphQL/awk programs, SC2126 grep|wc style).
+
+# Disabled checks (with rationale):
+#   SC2155 - `local x=$(cmd)` masking the command exit status; pervasive across
+#            these scripts and intentional (the exit status is not consumed).
+#   SC2034 - vars that look unused but are consumed by the script that sources
+#            the library (scripts/lib/*.sh).
+#   SC2064 - a trap that expands a known, fixed local path at definition time
+#            (bin/gh-task) — intended behavior here.
+#   SC1090/SC1091 - dynamic/relative `source` paths resolved at runtime.
+disable=SC2155,SC2034,SC2064,SC1090,SC1091

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2026-04-15
 
 ### Added
+
 - **Project governance & infrastructure**
   - `.github/CODEOWNERS` — default code ownership (proc-03 compliance)
   - `.github/dependabot.yml` — automated dependency updates for npm and GitHub Actions (sec-01 compliance)
@@ -100,27 +101,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `standards/shared/blocks/role-app.md` — UI-validation requirement injected into every assembled `role: app` agent config via the existing block-assembly system
 
 ### Changed
+
 - `.aiderrc` re-synced with canonical `aiderrc.template`; drops 97 lines of stale inline P0/P1 security list now sourced via the block assembly system (#34, #69)
 - Default Aider model bumped to `claude-sonnet-4-6` (current Sonnet 4.6 family alias) (#70)
 - Restructured `CHANGELOG.md` with versioned release sections
 
 ### Fixed
+
 - `standards-review` composite GitHub Action failed to load in consumer repos with `could not find expected ':'` YAML parse error. A Python heredoc inside a `run: |` block was indented at column 0, terminating the YAML literal block scalar so the parser interpreted Python as YAML. The formatter is now a sibling `format-results.py` invoked via `${{ github.action_path }}` (#64, #66)
 
 ## [0.5.0] - 2026-03-03
 
 ### Added
+
 - **Language-aware bootstrap** for Claude Code settings (#24)
   - Automatic language detection from project files
   - Dynamic `settings.json` generation with language-specific tool configs
   - CI test infrastructure for bootstrap validation
 
 ### Fixed
+
 - Corrected invalid Claude Code `settings.json` template (#23)
 
 ## [0.4.0] - 2026-03-03
 
 ### Added
+
 - **Security Standards Framework** (`standards/security/sec-01_security_standards.md`) (#22)
   - P0-P2 severity model (P0/P1 block merge, P2 flagged as warning)
   - 8 security categories: injection, auth, secrets, dangerous functions, dependencies, config, data protection, SAST tooling
@@ -133,15 +139,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2026-03-03
 
 ### Added
+
 - **Ruby standards** (`lang-10_ruby_standards.md`) (#21)
 - **Ruby on Rails standards** (`lang-11_ruby_on_rails_standards.md`) (#21)
 
 ### Changed
+
 - Restructured language file numbering to accommodate new languages (#21)
 
 ## [0.2.0] - 2026-03-02
 
 ### Added
+
 - `CLAUDE.md` for Claude Code project instructions (#20)
 - Gemini CLI and Antigravity support with `.gemini/` configuration (#20)
 - Marketing website with Starlight documentation site (#19)
@@ -149,12 +158,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/changelog.md` for website changelog rendering
 
 ### Changed
+
 - Updated setup/sync scripts with Gemini CLI detection (#20)
 - Public launch improvements: collaboration docs, CI workflows (#19)
 
 ## [0.1.0] - 2025-12-22
 
 ### Added
+
 - **GitHub Project Lifecycle Automation Suite**
   - `bin/gh-task` — CLI tool for GitHub Projects V2 integration
   - Commands: `create`, `start`, `status`, `update`, `submit`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ There are no build steps, no test suites, and no application to run. The primary
 ### Standards Documents (`standards/`)
 
 Markdown files organized by category with prefix-based naming:
+
 - `architecture/` (arch-01, arch-02, arch-04–arch-08): Core architecture, automation, data versioning/migration, resilient patterns, monorepo/workspace, cross-platform shared-core, CI/CD pipeline
 - `languages/` (lang-01 through lang-13): Python, Java, Kotlin, Swift, Dart, TypeScript, JavaScript, Rust, Zig, Ruby, Ruby on Rails, Go, Elixir
 - `process/` (proc-01 through proc-04): Documentation, git/version control, code review, agent workflow
@@ -47,6 +48,7 @@ Markdown files organized by category with prefix-based naming:
 ### Agent Configurations (`standards/agents/`)
 
 Template configs deployed to consumer projects during setup:
+
 - `claude-code/base-claude-code.md` — Claude Code (assembled to `CLAUDE.md`)
 - `cursor/` — Cursor AI (assembled to `.cursorrules`)
 - `copilot/.github/copilot-instructions.md` — GitHub Copilot
@@ -57,6 +59,7 @@ Template configs deployed to consumer projects during setup:
 ### Scripts (`scripts/`)
 
 All bash. Key scripts:
+
 - `setup.sh` — Installs standards into a target project, detects and configures AI agents; copies the standards-review workflow template only when run with `--workflow`
 - `sync-standards.sh` — Pulls latest standards and updates agent configs in consumer projects
 - `lint-standards.sh` — Standards compliance linter; outputs text, JSON, or SARIF

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -48,7 +48,7 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of unacceptable behavior may be reported by opening an issue at
-https://github.com/c65llc/coding-standards/issues or by contacting the project
+<https://github.com/c65llc/coding-standards/issues> or by contacting the project
 team directly.
 
 All complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ This project is designed to be forked and tailored to your organization. Here is
    [github.com/c65llc/coding-standards](https://github.com/c65llc/coding-standards).
 
 2. **Clone your fork**
+
    ```bash
    git clone https://github.com/YOUR_ORG/coding-standards.git
    cd coding-standards
@@ -47,17 +48,20 @@ This project is designed to be forked and tailored to your organization. Here is
 
 4. **Point the installer at your fork** -- When installing in projects, use your
    fork URL:
+
    ```bash
    STANDARDS_REPO_URL="https://github.com/YOUR_ORG/coding-standards" \
      curl -fsSL https://raw.githubusercontent.com/YOUR_ORG/coding-standards/main/install.sh | bash
    ```
 
 5. **Keep your fork updated from upstream**
+
    ```bash
    git remote add upstream https://github.com/c65llc/coding-standards.git
    git fetch upstream
    git merge upstream/main
    ```
+
    Resolve any conflicts where your customizations diverge from upstream, then push
    to your fork.
 

--- a/Makefile
+++ b/Makefile
@@ -57,28 +57,18 @@ format: ## Format all markdown files (if formatter available)
 		echo "ℹ️  prettier not installed, skipping"
 
 test-scripts: ## Test setup and sync scripts
-	@echo "Testing setup.sh..."
-	@bash -n scripts/setup.sh && echo "✅ setup.sh syntax valid"
-	@echo "Testing sync-standards.sh..."
-	@bash -n scripts/sync-standards.sh && echo "✅ sync-standards.sh syntax valid"
-	@echo "Testing detect-languages.sh..."
-	@bash -n scripts/detect-languages.sh && echo "✅ detect-languages.sh syntax valid"
-	@echo "Testing build-claude-settings.sh..."
-	@bash -n scripts/build-claude-settings.sh && echo "✅ build-claude-settings.sh syntax valid"
-	@echo "Testing assemble-config.sh..."
-	@bash -n scripts/assemble-config.sh && echo "✅ assemble-config.sh syntax valid"
-	@echo "Testing doctor.sh..."
-	@bash -n scripts/doctor.sh && echo "✅ doctor.sh syntax valid"
-	@echo "Testing diff-standards.sh..."
-	@bash -n scripts/diff-standards.sh && echo "✅ diff-standards.sh syntax valid"
-	@echo "Testing lib/checksums.sh..."
-	@bash -n scripts/lib/checksums.sh && echo "✅ lib/checksums.sh syntax valid"
-	@echo "Testing sync-content.sh..."
-	@bash -n website/scripts/sync-content.sh && echo "✅ sync-content.sh syntax valid"
-	@echo "Testing gh-task..."
-	@bash -n bin/gh-task && echo "✅ gh-task syntax valid"
-	@echo "Testing lint check scripts..."
-	@find scripts/lint-checks -name "*.sh" -exec bash -n {} \; && echo "✅ All lint check scripts syntax valid"
+	@echo "Syntax-checking all shell scripts (bash -n)..."
+	@fail=0; \
+	for f in $$(find scripts website/scripts -name '*.sh' 2>/dev/null) bin/gh-task; do \
+		[ -f "$$f" ] || continue; \
+		if bash -n "$$f"; then \
+			echo "  ✅ $$f"; \
+		else \
+			echo "  ❌ $$f"; fail=1; \
+		fi; \
+	done; \
+	if [ "$$fail" -ne 0 ]; then echo "❌ Syntax errors found"; exit 1; fi; \
+	echo "✅ All shell scripts syntax valid"
 	@echo "Testing format-results.py..."
 	@./scripts/test-format-results.sh
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ format: ## Format all markdown files (if formatter available)
 test-scripts: ## Test setup and sync scripts
 	@echo "Syntax-checking all shell scripts (bash -n)..."
 	@fail=0; \
-	for f in $$(find scripts website/scripts -name '*.sh' 2>/dev/null) bin/gh-task; do \
+	for f in $$(find scripts website/scripts -name '*.sh' 2>/dev/null) bin/gh-task install.sh; do \
 		[ -f "$$f" ] || continue; \
 		if bash -n "$$f"; then \
 			echo "  ✅ $$f"; \

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -4,7 +4,7 @@ This document explains the reorganized file hierarchy for easier navigation and 
 
 ## Directory Organization
 
-```
+```text
 .
 ├── .cursorrules                    # Cursor AI configuration (root level for easy access)
 ├── .gemini/                        # Gemini CLI & Antigravity configuration
@@ -165,4 +165,3 @@ If you have existing projects using the old structure:
 3. **Update Makefile** - Use `make setup` (automatically uses new paths)
 
 The reorganization is backward-compatible through the updated scripts and `.cursorrules` file.
-


### PR DESCRIPTION
Batch 3 of the full-repo-audit cleanup: CI and workflow hardening.

> **Merge order:** the new *Lint Standards (dogfood)* job asserts `--format sarif` runs without crashing, which depends on the zero-findings fix in **#146 (Batch 1)**. Merge #146 first, then rebase this branch. Until then that one job is expected red.

## #128 — CI coverage gaps
- **Concurrency groups** added to `ci.yml`, `definition-of-done.yml`, `lifecycle-sync.yml`.
- **ShellCheck scope** expanded to the whole shell tree (`scripts/`, `scripts/lib/`, `scripts/lint-checks/`, `bin/gh-task`, `install.sh`) with `-x` + a documented `.shellcheckrc` and `--severity=warning`. Verified locally: **no error-severity findings**.
- **`test-setup-safe.sh`** now runs in CI.
- **`make test-scripts`** globs every shell script instead of a hand-picked list (was missing ~10).
- **markdownlint** now covers root `*.md` (auto-fixed pre-existing cosmetic violations; `REVIEW.md` excluded pending #140).

## #127 — dogfood the linter
New **Lint Standards (dogfood)** job runs `lint-standards.sh` on this repo and asserts text/json/sarif execute without crashing and emit valid JSON — this is exactly what would have caught the #132 crash.

## #108 — pin actions to exact SHAs
`checkout`, `setup-node`, `setup-python`, `github-script`, `codeql-action` pinned to commit SHAs (with `# vX` comments) across all workflows.

## #134 — Definition of Done
- Default `node_version` **18 → 22**.
- Advisory checks (lint/coverage/security/CodeQL) **labeled honestly** so non-enforcing steps aren't mistaken for gates (tests remain the enforcing step).
- Summary comment is **edited in place** (hidden marker) instead of stacking a new comment each run.

## #135 — lifecycle-sync pagination
Project-item lookup now **paginates all items** (was `items(first: 100)`, failing open past 100) and **surfaces a warning annotation** when the issue isn't found.

## #141 — release automation
- **release-drafter** config + workflow: drafts categorized notes, auto-labels PRs from Conventional Commit titles.
- `publish.yml` now uses **`--force-with-lease`** (leased against `live`'s current SHA) so an out-of-band commit on `live` isn't clobbered.

## Verification
- `actionlint` ✅ (exit 0) · all workflow YAML parses ✅
- Full-tree `shellcheck -x --severity=warning` ✅ clean
- `make test-scripts`, `test-setup-safe.sh` ✅
- Root markdown passes markdownlint (excl. REVIEW.md) ✅
- Action SHAs resolved via the GitHub API from their current major tags

Closes #128
Closes #127
Closes #108
Closes #134
Closes #135
Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)