### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Add entries under the standard Keep a Changelog headings as work lands:
 ### Added / ### Changed / ### Deprecated / ### Removed / ### Fixed / ### Security -->
 
+## [1.5.0] - 2026-07-05
+
+A full-repo audit turned up ~30 issues across shell scripts, CI, docs, and the
+standards themselves. This release lands the fixes in reviewable batches, plus a
+round of standards enrichment from real cross-platform development.
+
+### Added
+
+- **Release automation (#141):** a `release-drafter` config and workflow keep a
+  categorized draft release continuously up to date from merged PRs and
+  auto-label PRs from their Conventional Commit title.
+- **TruffleHog secret scanning (#58):** ship `templates/.trufflehog-ignore` (a
+  documented `--exclude-paths` allowlist) and `templates/trufflehog.yml.example`
+  (merge-blocking, verification-off, SHA-pinned). `setup.sh` installs the
+  allowlist by default and the workflow with `--workflow`; `sec-01 §3` now
+  recommends TruffleHog and documents the suppression mechanisms.
+- **Linter dogfooding + docs (#127, #145):** a CI job runs `lint-standards.sh`
+  against this repo and asserts text/JSON/SARIF run without crashing; a new
+  `scripts/lint-checks/README.md` documents the enforced set (Python,
+  TypeScript, Go, Elixir + common) vs. the nine standards-only languages, with a
+  roadmap.
+- **Functional test coverage (#144):** `scripts/test-lint-standards.sh` covers
+  the linter's output formats and check modules; the safe-setup suite gains
+  TruffleHog install tests.
+- **Standards enrichment** from a real TS/Rust/Swift local-first monorepo:
+  leader-protocol versioning + self-healing (`arch-05`, #119); alias ordering
+  and bundler/test config parity (`arch-06`, #115); cold-rebuild drift gate and
+  release-version fan-out across platforms (`arch-07`, #114/#118); self-hosted
+  runner isolation and a post-promote production smoke check (`arch-08`/`proc-02`,
+  #116/#117); an auditable per-release manual-QA checklist (`core-standards`,
+  #121); regenerate visual baselines in CI, never locally (`testing-policy`/
+  `lang-06`, #120); JS/TS lockfile + package-manager hygiene with
+  `.prettierignore`/`.npmrc` templates (`#86`).
+- **Dependabot ergonomics (#139):** grouped npm and github-actions updates with
+  auto-merge for patch/minor bumps (majors stay manual).
+- Shared script libraries `scripts/lib/languages.sh` and `scripts/lib/dry-run.sh`
+  (#142).
+
+### Changed
+
+- **CI hardening (#128, #108):** added concurrency groups; expanded ShellCheck to
+  the whole shell tree (with a documented `.shellcheckrc`); run
+  `test-setup-safe.sh` in CI; `make test-scripts` now globs every shell script;
+  markdownlint covers root markdown; all GitHub Actions pinned to exact commit
+  SHAs.
+- **Definition of Done (#134):** default Node `18 → 22`, advisory checks labeled
+  honestly (so non-enforcing steps aren't mistaken for gates), and the summary
+  comment is edited in place instead of stacked each run.
+- **Lifecycle sync (#135):** project-item lookup paginates all items (was capped
+  at 100 and failing open) and surfaces a warning when the issue isn't found.
+- **Publish (#141):** `live` is advanced with `--force-with-lease` so an
+  out-of-band commit isn't clobbered.
+- **Website deps (#122–#126):** Astro `6 → 7`, Starlight, `starlight-blog`,
+  `@astrojs/rss`, and `sharp` upgraded together (build re-verified).
+- **Docs alignment:** `proc-02` distinguishes branch prefixes from Conventional
+  Commit types (#138); `--workflow` install is documented as opt-in with the
+  correct path (#143); agent configs and docs are re-synced to the standards
+  tree — the deleted `arch-03` removed, Go/Elixir (`lang-12`/`lang-13`) added,
+  Codex pointed at `AGENTS.md` (#136).
+
+### Fixed
+
+- `lint-standards.sh --format json/sarif` no longer crashes on zero findings
+  under bash 3.2 — the exact path the standards-review action runs (#132).
+- `gh-task`: parse `.gh-task-state` as data instead of `source`-ing it (arbitrary
+  code execution), honor the documented repo config keys, handle a repo with no
+  commits, abort instead of opening an empty-title PR (#133), and use portable
+  `grep -Eo` instead of macOS-unsupported `grep -oP` (#129).
+- `generate-pr-content.sh` no longer deletes the output file (via an EXIT trap)
+  before any consumer can read the path it printed (#131).
+- `install.sh` reads its prompt from `/dev/tty` (with a `STANDARDS_ASSUME_YES`
+  opt-in) so it works under `curl | bash`, and hardens shell options (#130).
+
+### Removed
+
+- Orphaned `landing-page.png` (~250KB) and the stale `REVIEW.md` improvement-plan
+  doc (its items are now tracked as issues) (#140).
+
+### Security
+
+- TruffleHog secret-scanning config and `sec-01 §3` guidance (#58) — see Added.
+
 ## [1.4.0] - 2026-06-18
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,151 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- Add entries under the standard Keep a Changelog headings as work lands:
+### Added / ### Changed / ### Deprecated / ### Removed / ### Fixed / ### Security -->
+
+## [1.5.0] - 2026-07-05
+
+A full-repo audit turned up ~30 issues across shell scripts, CI, docs, and the
+standards themselves. This release lands the fixes in reviewable batches, plus a
+round of standards enrichment from real cross-platform development.
+
+### Added
+
+- **Release automation (#141):** a `release-drafter` config and workflow keep a
+  categorized draft release continuously up to date from merged PRs and
+  auto-label PRs from their Conventional Commit title.
+- **TruffleHog secret scanning (#58):** ship `templates/.trufflehog-ignore` (a
+  documented `--exclude-paths` allowlist) and `templates/trufflehog.yml.example`
+  (merge-blocking, verification-off, SHA-pinned). `setup.sh` installs the
+  allowlist by default and the workflow with `--workflow`; `sec-01 §3` now
+  recommends TruffleHog and documents the suppression mechanisms.
+- **Linter dogfooding + docs (#127, #145):** a CI job runs `lint-standards.sh`
+  against this repo and asserts text/JSON/SARIF run without crashing; a new
+  `scripts/lint-checks/README.md` documents the enforced set (Python,
+  TypeScript, Go, Elixir + common) vs. the nine standards-only languages, with a
+  roadmap.
+- **Functional test coverage (#144):** `scripts/test-lint-standards.sh` covers
+  the linter's output formats and check modules; the safe-setup suite gains
+  TruffleHog install tests.
+- **Standards enrichment** from a real TS/Rust/Swift local-first monorepo:
+  leader-protocol versioning + self-healing (`arch-05`, #119); alias ordering
+  and bundler/test config parity (`arch-06`, #115); cold-rebuild drift gate and
+  release-version fan-out across platforms (`arch-07`, #114/#118); self-hosted
+  runner isolation and a post-promote production smoke check (`arch-08`/`proc-02`,
+  #116/#117); an auditable per-release manual-QA checklist (`core-standards`,
+  #121); regenerate visual baselines in CI, never locally (`testing-policy`/
+  `lang-06`, #120); JS/TS lockfile + package-manager hygiene with
+  `.prettierignore`/`.npmrc` templates (`#86`).
+- **Dependabot ergonomics (#139):** grouped npm and github-actions updates with
+  auto-merge for patch/minor bumps (majors stay manual).
+- Shared script libraries `scripts/lib/languages.sh` and `scripts/lib/dry-run.sh`
+  (#142).
+
+### Changed
+
+- **CI hardening (#128, #108):** added concurrency groups; expanded ShellCheck to
+  the whole shell tree (with a documented `.shellcheckrc`); run
+  `test-setup-safe.sh` in CI; `make test-scripts` now globs every shell script;
+  markdownlint covers root markdown; all GitHub Actions pinned to exact commit
+  SHAs.
+- **Definition of Done (#134):** default Node `18 → 22`, advisory checks labeled
+  honestly (so non-enforcing steps aren't mistaken for gates), and the summary
+  comment is edited in place instead of stacked each run.
+- **Lifecycle sync (#135):** project-item lookup paginates all items (was capped
+  at 100 and failing open) and surfaces a warning when the issue isn't found.
+- **Publish (#141):** `live` is advanced with `--force-with-lease` so an
+  out-of-band commit isn't clobbered.
+- **Website deps (#122–#126):** Astro `6 → 7`, Starlight, `starlight-blog`,
+  `@astrojs/rss`, and `sharp` upgraded together (build re-verified).
+- **Docs alignment:** `proc-02` distinguishes branch prefixes from Conventional
+  Commit types (#138); `--workflow` install is documented as opt-in with the
+  correct path (#143); agent configs and docs are re-synced to the standards
+  tree — the deleted `arch-03` removed, Go/Elixir (`lang-12`/`lang-13`) added,
+  Codex pointed at `AGENTS.md` (#136).
+
+### Fixed
+
+- `lint-standards.sh --format json/sarif` no longer crashes on zero findings
+  under bash 3.2 — the exact path the standards-review action runs (#132).
+- `gh-task`: parse `.gh-task-state` as data instead of `source`-ing it (arbitrary
+  code execution), honor the documented repo config keys, handle a repo with no
+  commits, abort instead of opening an empty-title PR (#133), and use portable
+  `grep -Eo` instead of macOS-unsupported `grep -oP` (#129).
+- `generate-pr-content.sh` no longer deletes the output file (via an EXIT trap)
+  before any consumer can read the path it printed (#131).
+- `install.sh` reads its prompt from `/dev/tty` (with a `STANDARDS_ASSUME_YES`
+  opt-in) so it works under `curl | bash`, and hardens shell options (#130).
+
+### Removed
+
+- Orphaned `landing-page.png` (~250KB) and the stale `REVIEW.md` improvement-plan
+  doc (its items are now tracked as issues) (#140).
+
+### Security
+
+- TruffleHog secret-scanning config and `sec-01 §3` guidance (#58) — see Added.
+
+## [1.4.0] - 2026-06-18
+
+### Changed
+
+- **Hosting:** migrated the documentation site from GitHub Pages to **Cloudflare Pages** via Cloudflare's **GitHub integration** (no API tokens/secrets in the repo). Cloudflare's production branch is `live`; a secret-free `publish.yml` (using `GITHUB_TOKEN`) fast-forwards `live` only on a **release cut** or a **new/edited blog post**, so the site republishes on exactly those events — not on every docs/standards merge. Drops the GitHub Pages `CNAME` marker and adds CF Pages `_headers`. Fixes the cross-provider TLS failure (GitHub ACME `bad_authz` behind the Cloudflare proxy → HTTP 526). Dashboard setup is documented in `docs/deploy.md`. (#104)
+- **CI:** the website CI build installs with `npm ci` (frozen lockfile) instead of `rm -rf node_modules package-lock.json && npm install`, and the committed `website/package-lock.json` was regenerated so it builds cleanly — reproducible builds (per the frozen-install standard in `arch-02`/`core-standards`), and Cloudflare's build uses the same lockfile. (#104)
+
+## [1.3.1] - 2026-06-18
+
+### Fixed
+
+- **Release hygiene:** backfilled the `v1.2.0` git tag and GitHub release (CHANGELOG `[1.2.0]`, PR #77, commit `298d64e`) that were finalized in the changelog but never published — restoring a contiguous tag/release history (previously jumped `v1.1.0` → `v1.3.0`).
+
+## [1.3.0] - 2026-06-18
+
+### Changed
+
+- **Documentation / releases (`proc-01 §4`, `shared/blocks/documentation-policy.md`):** projects with release automation (semantic-release, release-please, Changesets) must NOT hand-maintain a shared `## [Unreleased]` changelog block per PR — rely on generated notes or per-PR changeset fragments (avoids predictable merge conflicts under parallel work). (#88)
+- **Automation (`arch-02 §2`):** added `make test-e2e` (scoped to projects with a browser/integration surface) and a `make verify` pre-merge gate that includes build + e2e; e2e runners that serve a prebuilt artifact must rebuild first (no stale-artifact false greens). (#89)
+- **TypeScript (`lang-06 §1`):** Node **runtime** pinning must be ENFORCED (engine-strict / preinstall guard), not just declared, so a wrong runtime fails fast instead of a cryptic native-build error; pin the **package manager** separately via `packageManager`/Corepack. (#90)
+- **TypeScript testing (`lang-06 §7`):** added anti-brittleness rules — no asserting on raw source text, no test-only markup, deterministic (locale-pinned) formatted-output assertions, and container-scoped queries. (#91)
+
+### Added
+
+- **`arch-06_monorepo_workspace_standards.md`** (new): multi-toolchain workspaces kept separate, per-member pipeline ownership ("own your scope, not your style"), running the build (not just typecheck), complete path/alias resolution across all resolvers, generated-artifact drift gates (clean-rebuild to reproduce), and workspace dependency hygiene.
+- **`arch-07_cross_platform_shared_core_standards.md`** (new): shared pure core + thin per-platform shells, conformance/golden-vector testing as the parity gate, FFI boundary coverage (export smoke / golden parity / edge cases), UI-changes-are-cross-platform-by-default scoping, and testing to the platform edges.
+- **`arch-08_ci_cd_pipeline_standards.md`** (new): local gate mirrors CI, consolidate the required gate + build once, don't-run-everything-per-PR (concurrency cancel, path filters, tiered heavy suites), caching (pinned actions, keyed/evicted caches), artifact retention, self-hosted runner caveats, and deploy channels & promotion.
+- `proc-03_code_review_expectations.md`: a **PR Definition of Done / merge loop** (full local gate → open → wait for automated review → address all feedback → all-green → squash-merge), automated/AI review treated as a first-class gate with an author self-review checklist of common findings, and a UI-PRs-need-sign-off case.
+- `proc-02_git_version_control_standards.md` § 5/§ 11: release-version vs build-version model, deploy channels & promotion, the scripted reviewable release cut, and a Stacked & Dependent PRs section (base-deletion trap, conflicting-PR-runs-no-checks, one `Closes #X` per line, `gh pr create` cwd inference).
+- `proc-04_agent_workflow_standards.md`: Worktree Hygiene (volatile root checkout, `gh pr create` cwd, frozen-lockfile install in fresh worktrees, hook repair) and UI sign-off / environment-specific visual baselines / cross-platform UI scope.
+- `arch-02_automation_standards.md`: `make hooks` target and stronger `make dev` provisioning (all toolchains + hooks, frozen-lockfile installs).
+- `arch-05_resilient_architecture_patterns.md` §§ 7–9: best-effort/isolated secondary subsystems, liveness & takeover for coordination singletons, and "don't swallow the root cause."
+- `core-standards.md`: an Untestable Boundaries policy under Testing Standards (no dead-branch coverage gaming; keep boundaries thin; flag manual verification) and references to the new `arch-06`/`arch-07`/`arch-08` standards.
+- Shared blocks updated to propagate into assembled agent configs: `git-workflow` (merge loop, small/stacked PRs, `gh pr create` cwd, stacked-PR retarget), `testing-policy` (untestable boundaries, run the build), `architecture-core` (best-effort secondary subsystems, preserve the cause).
+- `lang-04_swift_standards.md § 14`: Build & Project Generation (Apple platforms) — XcodeGen/Tuist as project source of truth, code-signing rules (set `DEVELOPMENT_TEAM`, never disable signing at `base`), CI override pattern, a diagnostic checklist for "code is unsigned" device-install failures, and a note (§14.5) on latent target-config gaps that surface when re-enabling signing (e.g. test targets requiring `GENERATE_INFOPLIST_FILE: YES`).
+
+## [1.2.0] - 2026-04-16
+
+### Changed — Safe setup (breaking for setup.sh defaults)
+
+- **`setup.sh` no longer clobbers existing agent configs.** Every assembly now routes through `should_assemble()`; customized files are staged as `.standards-pending/<file>` instead of overwritten. Applies to `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`, `AGENTS.md`, `.aider-instructions.md`.
+- **`--agents` defaults to `detect`** (was: install all six). Setup now probes for existing config files (`CLAUDE.md`, `.cursorrules`, etc.) and installs only for agents already in use. Escape hatches: `--agents all`, `--agents claude-code,cursor`, or explicit comma-separated list.
+- **`--workflow` gates the `standards-review.yml` install.** Previously copied unconditionally when missing; now opt-in. When skipped, setup prints the hint: `To install: ./setup.sh --workflow`.
+- **Template variables in `CLAUDE.md` are now resolved.** `{{PROJECT_NAME}}` is filled from `package.json` / `Cargo.toml` / `pyproject.toml` / directory name. `{{PROJECT_OVERVIEW}}` and `{{KEY_COMMANDS}}` are rewritten to `<!-- TODO(standards): -->` markers the merge skill fills in — never shipped as literal `{{...}}`.
+
+### Added
+
+- **`scripts/lib/assembly.sh`** — shared `assemble_agent_config_guarded()` used by both `setup.sh` and `sync-standards.sh`. First-run and re-sync now behave identically.
+- **`scripts/lib/detect-agents.sh`** — `detect_installed_agents()` probe used by `--agents detect`.
+- **`scripts/lib/template-vars.sh`** — `resolve_project_name`, `resolve_template_vars`.
+- **`scripts/lib/merge-plan.sh`** — `write_merge_plan()` emits `.standards-pending/MERGE_PLAN.md`.
+- **`.cursor/commands/merge-standards.md`** — Cursor-facing twin of the Claude Code skill.
+- **`make merge-standards`** — prints `MERGE_PLAN.md` for manual or agent-agnostic workflows.
+- **`scripts/test-setup-safe.sh`** — 17 functional tests for pending-mode writes, agent detection, template-var resolution, workflow gate, MERGE_PLAN emission. Wired into `make test`.
+
+### Fixed
+
+- Re-running `setup.sh` on a project that already has customized `AGENTS.md` / `CLAUDE.md` no longer discards the user's work.
+- Assembled `CLAUDE.md` never ships with literal `{{PROJECT_NAME}}`, `{{PROJECT_OVERVIEW}}`, or `{{KEY_COMMANDS}}` tokens.
+
 ## [1.1.0] - 2026-04-15
 
 ### Added
@@ -82,26 +227,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Ruby standards** (`lang-10_ruby_standards.md`)
-- **Ruby on Rails standards** (`lang-11_ruby_on_rails_standards.md`)
+- **Ruby standards** (`lang-10_ruby_standards.md`) (#21)
+- **Ruby on Rails standards** (`lang-11_ruby_on_rails_standards.md`) (#21)
 
 ### Changed
 
-- Restructured language file numbering to accommodate new languages
+- Restructured language file numbering to accommodate new languages (#21)
 
 ## [0.2.0] - 2026-03-02
 
 ### Added
 
-- `CLAUDE.md` for Claude Code project instructions
-- Gemini CLI and Antigravity support with `.gemini/` configuration
-- Marketing website with Starlight documentation site
+- `CLAUDE.md` for Claude Code project instructions (#20)
+- Gemini CLI and Antigravity support with `.gemini/` configuration (#20)
+- Marketing website with Starlight documentation site (#19)
 - Comprehensive documentation: getting started, guides, reference
+- `docs/changelog.md` for website changelog rendering
 
 ### Changed
 
-- Updated setup/sync scripts with Gemini CLI detection
-- Public launch improvements: collaboration docs, CI workflows
+- Updated setup/sync scripts with Gemini CLI detection (#20)
+- Public launch improvements: collaboration docs, CI workflows (#19)
 
 ## [0.1.0] - 2025-12-22
 
@@ -110,11 +256,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Project Lifecycle Automation Suite**
   - `bin/gh-task` — CLI tool for GitHub Projects V2 integration
   - Commands: `create`, `start`, `status`, `update`, `submit`
+  - Automatic project status updates (Todo → In Progress → In Review → Done)
+  - Branch management with `task/<id>-<title>` naming convention
 - **Reusable GitHub Actions Workflows**
-- **PR Templates** and configuration templates
-- **Comprehensive Documentation** (gh-task guide, quick start, tooling)
+  - `.github/workflows/lifecycle-sync.yml` — auto-sync project status on PR events
+  - `.github/workflows/definition-of-done.yml` — quality checks for PRs
+- **PR Templates** (`.github/PULL_REQUEST_TEMPLATE/default.md`)
+- **Configuration Templates** for GitHub Projects V2
+- **Comprehensive Documentation**
+  - `docs/GH_TASK_GUIDE.md` — complete gh-task CLI reference
+  - `docs/GH_TASK_QUICKSTART.md` — 5-minute quick start guide
+  - `docs/TOOLING.md` — architecture and AI agent instructions
 - **Testing Infrastructure** (`scripts/test-gh-task.sh`)
 - Multi-agent support: Cursor, Copilot, Claude Code/Aider, Codex
-- Standards documents: architecture (3), languages (9), process (4), shared
+- `standards/shared/core-standards.md` — canonical cross-cutting standards
+- Standards documents: architecture (3), languages (9), process (4)
 - Setup and sync scripts for standards distribution via git submodule
 - One-line installer (`install.sh`)

--- a/website/src/content/docs/blog/a-green-pipeline-is-not-proof.md
+++ b/website/src/content/docs/blog/a-green-pipeline-is-not-proof.md
@@ -1,0 +1,38 @@
+---
+title: "A Green Pipeline Is Not Proof"
+date: 2026-07-05
+authors:
+  - name: C65 LLC
+---
+
+Alongside the [audit sweep](/blog/standards-1-5-audit-sweep/), 1.5 folds a batch of hard-won lessons into the architecture and process standards. They came out of real development on a TypeScript / Rust / Swift local-first monorepo — the kind of project these standards are meant for. Each one is a bug that a reasonable person would not have predicted, and that a green checkmark actively hid.
+
+## A green release that never reached production
+
+Twice, a release was cut, promoted, and reported green — while production never changed.
+
+The first time, the deploy platform's build token had been silently rolled. Every in-repo check passed because the failure lived entirely outside the repo: the git host had no idea the token was dead. The second time, a force-push protection on the `release` branch blocked the fast-forward promote. Same symptom: pipeline exits zero, nothing ships.
+
+The lesson is uncomfortable because it undercuts the thing we most want to believe: that a passing pipeline means the work is done. It doesn't. A pipeline proves the steps it ran exited zero. It cannot prove that a system it doesn't control — the deploy platform, its credentials, its branch rules — did what you asked. So `arch-08` and `proc-02` now require the release to **end by fetching the live deployment and asserting the new version is actually serving.** Necessary is not sufficient; the only proof that production updated is production.
+
+## A stale tab that bricked every new one
+
+The local-first app used a shared-worker leader/follower model — one tab owns the database, the rest coordinate through it. After a deploy, a browser tab left open from the *previous* version still held the leader lock. Every freshly loaded tab became a follower, probed the incompatible old leader, timed out, and retried the same doomed probe forever. The app was wedged, and nothing in the running code knew how to recover.
+
+Two fixes, now in `arch-05`. **Version the coordination protocol**, so a new follower recognizes an incompatible leader and triggers takeover instead of trusting it. And **distinguish transient failure from persistent failure** — retry is for hiccups; a persistent leader timeout means re-elect, not retry. A follower that retries a permanent condition forever isn't resilient, it's stuck.
+
+## Drift a warm build refused to show
+
+This one is subtle. The repo commits generated cross-platform artifacts — wasm blobs, UniFFI bindings. To catch drift, CI regenerates them and diffs against what's committed. Straightforward, except it kept passing while the artifacts were genuinely stale.
+
+The culprit was the warm build cache. An incremental `target/` directory happily produced the already-committed output from stale intermediate state; the drift only reproduced after a `cargo clean`. So the "regenerate and diff" gate was diffing against a lie. `arch-07` now requires the drift gate to **rebuild from a cold state** — clean first, or run in a fresh checkout — because a warm target masks exactly the drift the gate exists to catch.
+
+## The one that fails in seconds vs. the one that waits
+
+A smaller, sharper one for `arch-08`: two self-hosted runners sharing a machine produced collisions — duplicate listener stacks fighting over `_diag` paths, package-manager setup dirs racing on big fan-out PRs. The fix is isolation (each runner gets its own `HOME`, tool-cache, and work directory). But the lesson worth writing down was diagnostic: **an offline runner leaves a job queued and waiting; a misconfigured one fails at "Set up job" in seconds.** Same red check, opposite cause. Knowing which you're looking at saves an hour of debugging the wrong thing.
+
+## Why these belong in the standards
+
+None of these are exotic. They're the failure modes you only meet once you ship something real across more than one platform — and once you've met them, they're obvious. The point of a standards repo is to let the next team meet them as a paragraph in a document instead of as a production incident.
+
+That's the trade every entry in this batch makes: someone already paid for the lesson. The standard is just the receipt, filed where the next person will look.

--- a/website/src/content/docs/blog/standards-1-5-audit-sweep.md
+++ b/website/src/content/docs/blog/standards-1-5-audit-sweep.md
@@ -1,0 +1,40 @@
+---
+title: "Standards 1.5: The Audit Sweep"
+date: 2026-07-05
+authors:
+  - name: C65 LLC
+---
+
+Every few releases we stop shipping features and turn the audit on ourselves. This is one of those releases. We ran a full-repo sweep — scripts, CI, docs, and the standards documents themselves — and it surfaced about thirty distinct issues. 1.5 lands the fixes.
+
+The interesting part isn't the count. It's what the count was made of: not one big broken thing, but thirty small ones, each individually easy to wave off, that together added up to a repo quietly drifting from the standards it publishes.
+
+## The shape of the drift
+
+A few themes ran through almost everything we found.
+
+**Portability assumptions that only held on Linux.** The compliance linter (`lint-standards.sh`) crashed on `--format json` and `--format sarif` when there were zero findings — but only under bash 3.2, which is exactly what ships on macOS, and exactly the path the PR-review action runs. `gh-task` used `grep -oP`, a GNU-only flag that silently returns empty on a Mac. Both had lived in the tree for months because CI runs on Ubuntu and nobody hit them locally until they did.
+
+**Docs describing a repo that no longer existed.** The agent configs still told assistants to "strictly follow" `arch-03` — a standard we had deleted. Go and Elixir shipped as full language standards but were missing from every agent config's detection map. The README said the standards-review workflow was "installed automatically by `make setup`" when in fact it required an explicit `--workflow` flag. None of these break a build. All of them mislead a reader — or an agent — at exactly the moment they're trying to trust the document.
+
+**Gates that didn't gate.** The Definition-of-Done workflow ran linting, coverage, and security scans and then swallowed every failure with `|| true`. It looked like a quality gate and enforced almost nothing. The lifecycle-sync automation queried the first 100 project items and quietly stopped working past that. A "green" pipeline that proves nothing is worse than no pipeline, because it manufactures false confidence.
+
+**A `source` that would run anything.** `gh-task` read its state file with `source .gh-task-state` — executing whatever a tampered or mis-merged file put there, with your shell's privileges. That one we treated as a security fix, not a cleanup.
+
+## Batching the fix
+
+Thirty issues is too many for one pull request and too many to merge one-at-a-time without losing the plot. We grouped them by kind — script bugs, doc consistency, CI hardening, chores, dependency triage, standards enrichment — and shipped each as its own reviewable PR that closed a handful of issues at once. Each batch stated what it fixed, how it was verified, and what it deliberately left for later.
+
+That structure paid off when the batches started depending on each other. The new "dogfood" CI job — which runs our own linter against our own repo and asserts the JSON and SARIF output is valid — is a direct regression guard for the zero-findings crash. It literally cannot pass until the crash fix is present. So the batches had a merge order, and the order was part of the plan, not an afterthought.
+
+## What actually shipped
+
+The headline items:
+
+- **The linter now dogfoods.** CI runs `lint-standards.sh` against this repo on every push and fails if the tool crashes or emits malformed output. The bug that would have shipped a broken SARIF file to every consumer is now caught here first.
+- **Secret scanning that teams won't turn off.** We ship a TruffleHog config with a documented allowlist, verification off by default, and merge-blocking on real findings. Noisy scanners get disabled; a scanner with good false-positive hygiene stays on.
+- **Release automation.** A release-drafter workflow keeps a categorized draft release current from merged PRs and auto-labels them from their commit type. The changelog stops being a manual chore.
+- **Actions pinned to SHAs, Dependabot grouped.** Every workflow now pins actions to an exact commit, and Dependabot batches the updates so they stop piling up as one-PR-per-bump.
+- **Standards enrichment** from real cross-platform work — the subject of [the companion post](/blog/a-green-pipeline-is-not-proof/).
+
+There's a satisfying symmetry to fixing your own linter's crash by making your CI run your own linter. The repo is a little more like the thing it tells everyone else to build. That's the whole point of doing this on a schedule.


### PR DESCRIPTION
Cuts **v1.5.0** — the full-repo audit sweep plus standards enrichment.

## What's in this PR
- **CHANGELOG.md** — new `[1.5.0]` section summarizing everything landed in PRs #146–#153 (Added / Changed / Fixed / Removed / Security).
- **docs/changelog.md** — regenerated from the canonical `CHANGELOG.md`. This file (the website's changelog page source) had **drifted and was stuck at 1.1.0**; it now reflects the full history through 1.5.0.
- **Two blog posts:**
  - *Standards 1.5: The Audit Sweep* — the meta story of the ~30-issue audit and how it was batched.
  - *A Green Pipeline Is Not Proof* — distilling the cross-platform lessons (#114–#121) into narrative form.

## Verification
- `npm run build` ✅ (65 pages; both new posts render, cross-links resolve)
- `markdownlint` clean on `CHANGELOG.md` and `docs/changelog.md` (CI-linted)
- The website changelog now matches the canonical changelog

## After merge
Tag `v1.5.0` and publish the GitHub release; `publish.yml` advances `live` and Cloudflare republishes the site with the new changelog and posts. Future release notes are drafted automatically by the release-drafter workflow added in #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)